### PR TITLE
feat(reprocessing): add batchId to support reprocessing 

### DIFF
--- a/Dayflow/Dayflow/Core/AI/OllamaProvider.swift
+++ b/Dayflow/Dayflow/Core/AI/OllamaProvider.swift
@@ -463,7 +463,7 @@ final class OllamaProvider: LLMProvider {
                     urlRequest.setValue("Bearer lm-studio", forHTTPHeaderField: "Authorization")
                 }
                 urlRequest.httpBody = try JSONEncoder().encode(request)
-                urlRequest.timeoutInterval = 30.0  // 30-second timeout
+                urlRequest.timeoutInterval = 60.0  // 60-second timeout
                 
                 let apiStart = Date()
                 let requestBodyForLogging: Data?

--- a/Dayflow/Dayflow/Core/Recording/StorageManager.swift
+++ b/Dayflow/Dayflow/Core/Recording/StorageManager.swift
@@ -180,6 +180,7 @@ struct TimelineCard: Codable, Sendable, Identifiable {
     let videoSummaryURL: String? // Optional link to primary video summary
     let otherVideoSummaryURLs: [String]? // For merged cards, subsequent video URLs
     let appSites: AppSites?
+    let batchId: Int64? // Batch ID for reprocessing functionality
 }
 
 /// Metadata about a single LLM request/response cycle
@@ -611,7 +612,8 @@ final class StorageManager: StorageManaging, @unchecked Sendable {
                     distractions: distractions,
                     videoSummaryURL: row["video_summary_url"],
                     otherVideoSummaryURLs: nil,
-                    appSites: appSites
+                    appSites: appSites,
+                    batchId: row["batch_id"]
                 )
             }
         }) ?? []
@@ -689,7 +691,8 @@ final class StorageManager: StorageManaging, @unchecked Sendable {
                     distractions: distractions,
                     videoSummaryURL: row["video_summary_url"],
                     otherVideoSummaryURLs: nil,
-                    appSites: appSites
+                    appSites: appSites,
+                    batchId: row["batch_id"]
                 )
             }
         }
@@ -736,7 +739,8 @@ final class StorageManager: StorageManaging, @unchecked Sendable {
                     distractions: distractions,
                     videoSummaryURL: row["video_summary_url"],
                     otherVideoSummaryURLs: nil,
-                    appSites: appSites
+                    appSites: appSites,
+                    batchId: row["batch_id"]
                 )
             }
         }

--- a/Dayflow/Dayflow/Views/UI/CanvasTimelineDataView.swift
+++ b/Dayflow/Dayflow/Views/UI/CanvasTimelineDataView.swift
@@ -333,7 +333,8 @@ struct CanvasTimelineDataView: View {
                 distractions: card.distractions,
                 videoSummaryURL: card.videoSummaryURL,
                 screenshot: nil,
-                appSites: card.appSites
+                appSites: card.appSites,
+                batchId: card.batchId
             )
         }
     }

--- a/Dayflow/Dayflow/Views/UI/TimelineDataModels.swift
+++ b/Dayflow/Dayflow/Views/UI/TimelineDataModels.swift
@@ -23,6 +23,7 @@ struct TimelineActivity: Identifiable {
     let videoSummaryURL: String?
     let screenshot: NSImage?
     let appSites: AppSites?
+    let batchId: Int64? // Batch ID for reprocessing functionality
 }
 
 


### PR DESCRIPTION
**Thank you for the open source and sharing of the project!**

In the process of use, I noticed that although there are already functions related to reprocessing in the current architecture, these functions have not been called in the card view, resulting in the inability to re-analyze in the case of process failed.

In order to solve this problem, I try to make a (temporary) improvement on the existing logic:

-  Introduce the `batchId` attribute into the relevant storage service so that it can correctly locate and trigger the corresponding batch tasks when reprocessing.
- Add the call logic for reprocess in the card view, so that the reanalysis process can be initiated when the processing fails.

This is just a preliminary solution, which may need further optimization and adjustment in the future, but I hope it can help the project. **If you have any suggestions for improvement, welcome to point them out.**

> Linked Issue:  #12
