### PR TITLE
Fix formatting of Homebrew installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ open Dayflow.xcodeproj
 If you are using [Homebrew](https://brew.sh/), you can install [Dayflow](https://formulae.brew.sh/cask/dayflow) with:
 
 ```bash
-$ brew install --cask dayflow
+brew install --cask dayflow
 ```
 
 ---


### PR DESCRIPTION
Makes a minor update to the installation instructions in the `README.md` file for Dayflow. 

The change removes the unnecessary `$` from the installation command, making it easier to copy and paste the installation command.

From the user perspective, installation should be as easy as just copy the command from GitHub