### PR TITLE
Support macOS 13

### DIFF
--- a/Dayflow/Dayflow.xcodeproj/project.pbxproj
+++ b/Dayflow/Dayflow.xcodeproj/project.pbxproj
@@ -436,7 +436,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.1.10;
 				PRODUCT_BUNDLE_IDENTIFIER = teleportlabs.com.Dayflow;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -470,7 +470,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.1.10;
 				PRODUCT_BUNDLE_IDENTIFIER = teleportlabs.com.Dayflow;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Dayflow/Dayflow/Views/Components/TimelineCardColorPicker.swift
+++ b/Dayflow/Dayflow/Views/Components/TimelineCardColorPicker.swift
@@ -810,7 +810,10 @@ struct ColorOrganizerRoot: View {
                 .background(
                     RoundedRectangle(cornerRadius: 8)
                         .fill(canAddMore ? Color.white : Color.gray.opacity(0.1))
-                        .stroke(Color.black.opacity(canAddMore && !newCategoryName.isEmpty ? 0.25 : 0.12), lineWidth: 1)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color.black.opacity(canAddMore && !newCategoryName.isEmpty ? 0.25 : 0.12), lineWidth: 1)
+                        )
                         .animation(.easeOut(duration: 0.2), value: newCategoryName.isEmpty)
                 )
 

--- a/Dayflow/Dayflow/Views/Onboarding/APIKeyInputView.swift
+++ b/Dayflow/Dayflow/Views/Onboarding/APIKeyInputView.swift
@@ -50,7 +50,7 @@ struct APIKeyInputView: View {
                     }
                     .font(.custom("SF Mono", size: 13))
                     .focused($isFocused)
-                    .onChange(of: apiKey) { _, newValue in
+                    .onChange(of: apiKey) { newValue in
                         validateKey(newValue)
                     }
                     

--- a/Dayflow/Dayflow/Views/Onboarding/LLMProviderSetupView.swift
+++ b/Dayflow/Dayflow/Views/Onboarding/LLMProviderSetupView.swift
@@ -437,7 +437,7 @@ struct LLMProviderSetupView: View {
                                     .pickerStyle(.segmented)
                                     .frame(maxWidth: 380)
                                 }
-                                .onChange(of: setupState.localEngine) { _, newValue in
+                                .onChange(of: setupState.localEngine) { newValue in
                                     setupState.selectEngine(newValue)
                                 }
 


### PR DESCRIPTION
- Swapped every macOS 14-only `.onChange(of:initial:)` use for the legacy closure signature so onboarding flow compiles on macOS 13
- Reworked the color picker textbox border to render via `.overlay(.stroke())`, replacing the macOS 14-only chained `.fill(...).stroke(...)` style while preserving the visual design.

Tested on my macOS 13.0 device.