### PR TITLE
fix(ui): set menu bar icons as template images for light/dark adaptation

### DIFF
--- a/Dayflow/Dayflow/Assets.xcassets/MenuBarOffIcon.imageset/Contents.json
+++ b/Dayflow/Dayflow/Assets.xcassets/MenuBarOffIcon.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Dayflow/Dayflow/Assets.xcassets/MenuBarOnIcon.imageset/Contents.json
+++ b/Dayflow/Dayflow/Assets.xcassets/MenuBarOnIcon.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `template-rendering-intent: template` to MenuBarOnIcon and MenuBarOffIcon asset catalogs
- This allows macOS to automatically render the icons in black on light backgrounds and white on dark backgrounds

## Problem
The menu bar icon was always rendering white, even when other menu bar icons were black (on light menu bar backgrounds).

### Before
<img width="109" height="34" alt="SCR-20260129-mask" src="https://github.com/user-attachments/assets/10681691-f95e-428d-99c0-cdd797048fac" />

## Solution
Mark the icon assets as template images in the asset catalog. Template images let macOS handle the color rendering automatically based on the menu bar appearance.

### After
| Light Background | Dark Background |
|------------------|-----------------|
| <img width="104" height="34" alt="SCR-20260129-maua" src="https://github.com/user-attachments/assets/38d9d129-fc15-483f-bb76-1e1ffae1682d" /> | <img width="103" height="34" alt="SCR-20260129-maxw" src="https://github.com/user-attachments/assets/bf185037-a06d-4c21-9278-ce1514fcb1c8" /> |

---

Hey Jerry! Congratulations on building such awesome software - Dayflow is genuinely impressive. Here is my minor contribution to help out. Would love to be part of beta access for the Journal feature if possible!