### PR TITLE
feat: add chat options for context size

### DIFF
--- a/Dayflow/Dayflow/Core/AI/LLMService.swift
+++ b/Dayflow/Dayflow/Core/AI/LLMService.swift
@@ -606,6 +606,9 @@ final class LLMService: LLMServicing {
         let errorDescription = error.localizedDescription.lowercased()
         
         switch true {
+        case errorDescription.contains("context window") || errorDescription.contains("context length") || errorDescription.contains("max context") || errorDescription.contains("num_ctx"):
+            return "The local AI hit its context limit. Increase the context size in your local model settings (e.g., LM Studio or Ollama) or process a shorter recording."
+
         case errorDescription.contains("rate limit") || errorDescription.contains("429"):
             return "The AI service is temporarily overwhelmed. This usually resolves itself in a few minutes."
             


### PR DESCRIPTION
Issue #202
Processing sometimes fails silently with the default context window (~4096 tokens). Just stops and transcript just fails. After increasing the model context size manually, processing works as expected.