### PR TITLE
Feat/resizable right sidebar

### DIFF
--- a/Dayflow/Dayflow/Views/UI/MainView/Layout.swift
+++ b/Dayflow/Dayflow/Views/UI/MainView/Layout.swift
@@ -312,10 +312,24 @@ extension MainView {
     private func timelinePanel(geo: GeometryProxy) -> some View {
         HStack(alignment: .top, spacing: 0) {
             timelineLeftColumn
-            Rectangle()
-                .fill(Color(hex: "ECECEC"))
-                .frame(width: 1)
-                .frame(maxHeight: .infinity)
+
+            // Resize interaction area: thin visible divider + wider invisible drag handle
+            ZStack {
+                Rectangle()
+                    .fill(Color(hex: "ECECEC"))
+                    .frame(width: 1)
+
+                SidebarResizeHandle(
+                    width: Binding(
+                        get: { CGFloat(rightPanelWidthStorage) },
+                        set: { rightPanelWidthStorage = Double($0) }
+                    ),
+                    panelWidth: geo.size.width
+                )
+            }
+            .frame(maxHeight: .infinity)
+            .zIndex(20) // Ensure handle is above cards
+
             timelineRightColumn(geo: geo)
         }
         .frame(width: geo.size.width, height: geo.size.height, alignment: .topLeading)
@@ -583,7 +597,8 @@ extension MainView {
                 )
             )
         )
-        .frame(minWidth: 240, idealWidth: 358, maxWidth: 358, maxHeight: .infinity)
+        .frame(width: CGFloat(rightPanelWidthStorage))
+        .frame(maxHeight: .infinity)
     }
 
     private var overlayContent: some View {
@@ -780,5 +795,47 @@ private struct TimelineFailureToastView: View {
                 .stroke(Color(hex: "F3D9C2"), lineWidth: 1)
         )
         .shadow(color: Color.black.opacity(0.12), radius: 12, x: 0, y: 6)
+    }
+}
+
+struct SidebarResizeHandle: View {
+    @Binding var width: CGFloat
+    let panelWidth: CGFloat
+    let minWidth: CGFloat = 350
+
+    /// Max sidebar width is 40% of the total panel width
+    var maxWidth: CGFloat {
+        max(panelWidth * 0.4, minWidth)
+    }
+
+    @State private var dragStartWidth: CGFloat? = nil
+
+    var body: some View {
+        Rectangle()
+            .fill(Color.clear)
+            .frame(width: 6) // Wider hit area for ease of use
+            .contentShape(Rectangle())
+            .onHover { inside in
+                if inside {
+                    NSCursor.resizeLeftRight.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+            .gesture(
+                DragGesture(coordinateSpace: .global)
+                    .onChanged { value in
+                        // Capture the starting width on drag start
+                        if dragStartWidth == nil {
+                            dragStartWidth = width
+                        }
+                        // Dragging left (negative translation) increases width
+                        let newWidth = (dragStartWidth ?? width) - value.translation.width
+                        width = min(max(newWidth, minWidth), maxWidth)
+                    }
+                    .onEnded { _ in
+                        dragStartWidth = nil
+                    }
+            )
     }
 }

--- a/Dayflow/Dayflow/Views/UI/MainView/MainView.swift
+++ b/Dayflow/Dayflow/Views/UI/MainView/MainView.swift
@@ -15,6 +15,7 @@ import Sentry
 struct MainView: View {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var categoryStore: CategoryStore
+    @AppStorage("rightPanelWidth") var rightPanelWidthStorage: Double = 358
     @State var selectedIcon: SidebarIcon = .timeline
     @State var selectedDate = timelineDisplayDate(from: Date())
     @State var showDatePicker = false


### PR DESCRIPTION
# Resizable right sidebar panel

This PR introduces a improvement to the sidebar in the main view by allowing users to resize the right panel using a new drag handle. The changes include adding a custom `SidebarResizeHandle` component, updating the panel's width management, and enhancing the user interaction experience.

Sidebar resizing functionality:

* Added `SidebarResizeHandle` component to enable drag-based resizing of the right panel, with enforced minimum and maximum widths based on the overall panel size. The handle provides a wider invisible hit area for easier interaction and updates the cursor to indicate resizability. (`SidebarResizeHandle`, `Dayflow/Dayflow/Views/UI/MainView/Layout.swift`)
* Integrated the resize handle into the timeline panel layout, ensuring the handle is visually above other elements and interacts smoothly with the panel width state. (`timelinePanel`, `Dayflow/Dayflow/Views/UI/MainView/Layout.swift`)

Panel width management:

* Switched the right panel's width to be controlled by a persistent `@AppStorage` property (`rightPanelWidthStorage`), allowing the width to be retained across app launches. (`Dayflow/Dayflow/Views/UI/MainView/MainView.swift`)
* Updated the right panel's frame logic to use the dynamically stored width, replacing the previous fixed width constraints. (`timelineRightColumn`, `Dayflow/Dayflow/Views/UI/MainView/Layout.swift`)