### PR TITLE
fix: replace CGPreflightScreenCaptureAccess with SCShareableContent on macOS Sequoia

### DIFF
--- a/Dayflow/Dayflow/Views/Onboarding/OnboardingFlow.swift
+++ b/Dayflow/Dayflow/Views/Onboarding/OnboardingFlow.swift
@@ -210,21 +210,16 @@ struct OnboardingFlow: View {
             step.next()
             savedStepRawValue = step.rawValue
             
-            // Only try to start recording if we already have permission
-            if CGPreflightScreenCaptureAccess() {
-                Task {
-                    do {
-                        // Verify we have permission
-                        _ = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
-                        // Start recording
-                        await MainActor.run {
-                            AppState.shared.isRecording = true
-                        }
-                    } catch {
-                        // Permission not granted yet, that's ok
-                        // It will start after restart
-                        print("Will start recording after restart")
+            // Try to start recording if we have permission
+            Task {
+                do {
+                    _ = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+                    await MainActor.run {
+                        AppState.shared.isRecording = true
                     }
+                } catch {
+                    // Permission not granted yet, will start after restart
+                    print("Will start recording after restart")
                 }
             }
         case .completion:         

--- a/Dayflow/Dayflow/Views/UI/Settings/StorageSettingsViewModel.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/StorageSettingsViewModel.swift
@@ -1,7 +1,7 @@
 import AppKit
 import Combine
-import CoreGraphics
 import Foundation
+import ScreenCaptureKit
 
 @MainActor
 final class StorageSettingsViewModel: ObservableObject {
@@ -67,7 +67,13 @@ final class StorageSettingsViewModel: ObservableObject {
         }
 
         Task.detached(priority: .utility) { [weak self] in
-            let permission = CGPreflightScreenCaptureAccess()
+            let permission: Bool
+            do {
+                _ = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+                permission = true
+            } catch {
+                permission = false
+            }
             let recordingsURL = StorageManager.shared.recordingsRoot
 
             let recordingsSize = StorageSettingsViewModel.directorySize(at: recordingsURL)


### PR DESCRIPTION
## Summary
- macOS Sequoia에서 `CGPreflightScreenCaptureAccess()`가 TCC 권한이 허용(`auth_value=2`)되어 있어도 `false`를 반환하는 버그 수정
- `SCShareableContent.excludingDesktopWindows()` try/catch 패턴으로 교체하여 실제 권한 상태를 신뢰성 있게 확인
- Settings "Run status check"에서 "Screen recording permission missing"으로 잘못 표시되는 문제 해결

## Changed files (3)
- **StorageSettingsViewModel.swift**: `CGPreflightScreenCaptureAccess()` → `SCShareableContent` try/catch
- **ScreenRecordingPermissionView.swift**: `.onAppear`, `.onReceive`, `requestPermission()` 3곳 교체 (동기→비동기)
- **OnboardingFlow.swift**: 불필요한 `CGPreflightScreenCaptureAccess()` guard 제거, `SCShareableContent` 결과에만 의존

## Test plan
- [ ] Xcode 빌드 성공 확인 (verified locally)
- [ ] Settings → "Run status check" → "Screen recording permission granted" 표시 확인
- [ ] Onboarding flow에서 권한 부여 후 정상 진행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)