### PR TITLE
Revamp Settings Providers tab & fix multiple bugs

### DIFF
--- a/Dayflow/Dayflow/System/StatusBarController.swift
+++ b/Dayflow/Dayflow/System/StatusBarController.swift
@@ -51,6 +51,12 @@ final class StatusBarController: NSObject {
             })
         )
         popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-        popover.contentViewController?.view.window?.makeKey()
+        // Ensure popover appears above fullscreen windows and activates the app
+        if let popoverWindow = popover.contentViewController?.view.window {
+            popoverWindow.collectionBehavior = [.canJoinAllSpaces, .moveToActiveSpace, .fullScreenAuxiliary]
+            popoverWindow.makeKey()
+        }
+        NSApp.activate(ignoringOtherApps: true)
     }
 }
+

--- a/Dayflow/Dayflow/Views/UI/MainView/Layout.swift
+++ b/Dayflow/Dayflow/Views/UI/MainView/Layout.swift
@@ -206,6 +206,9 @@ extension MainView {
                 }
                 // Refresh weekly hours in case activities were added
                 loadWeeklyTrackedMinutes()
+                // Force timeline data refetch (fixes stale/missing cards after window reopen)
+                refreshActivitiesTrigger &+= 1
+                updateCardsToReviewCount()
             }
             .overlay { categoryEditorOverlay }
             .environmentObject(retryCoordinator)

--- a/Dayflow/Dayflow/Views/UI/Settings/ProviderCardView.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/ProviderCardView.swift
@@ -1,0 +1,190 @@
+//
+//  ProviderCardView.swift
+//  Dayflow
+//
+//  Compact provider card for the Settings providers tab
+//
+
+import SwiftUI
+
+struct ProviderCardView: View {
+    let provider: CompactProviderInfo
+    let isPrimary: Bool
+    let isSecondary: Bool
+    let isConfigured: Bool
+    let statusDetail: String?
+    let canSetPrimary: Bool
+    let canSetSecondary: Bool
+
+    let onEdit: () -> Void
+    let onConfigure: () -> Void
+    let onRemove: () -> Void
+    let onSetPrimary: () -> Void
+    let onSetSecondary: () -> Void
+
+    private let accentColor = Color(red: 0.25, green: 0.17, blue: 0)
+    private let buttonTextWidth: CGFloat = 120
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            headerRow
+            summaryText
+            actionButtons
+        }
+        .padding(14)
+        .background(isPrimary ? Color(hex: "FFF8EE") : Color.white.opacity(0.52))
+        .cornerRadius(10)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(
+                    isPrimary ? Color(hex: "FFE0A5") : Color.black.opacity(0.06),
+                    lineWidth: isPrimary ? 1.2 : 1
+                )
+        )
+    }
+
+    // MARK: - Header
+
+    private var headerRow: some View {
+        HStack(spacing: 10) {
+            ProviderIconView(icon: provider.icon)
+                .scaleEffect(0.7)
+                .frame(width: 28, height: 28)
+
+            Text(provider.providerTableName)
+                .font(.custom("Nunito", size: 15))
+                .fontWeight(.semibold)
+                .foregroundColor(.black.opacity(0.82))
+
+            Spacer()
+
+            statusBadge
+        }
+    }
+
+    @ViewBuilder
+    private var statusBadge: some View {
+        if isPrimary {
+            BadgeView(text: "PRIMARY", type: .orange)
+        } else if isSecondary {
+            BadgeView(text: "SECONDARY", type: .blue)
+        } else if isConfigured {
+            BadgeView(text: "CONFIGURED", type: .green)
+        } else {
+            BadgeView(text: "NOT SET", type: .green)
+                .opacity(0.5)
+        }
+    }
+
+    // MARK: - Summary
+
+    private var summaryText: some View {
+        Text(statusDetail ?? provider.summary)
+            .font(.custom("Nunito", size: 12))
+            .foregroundColor(.black.opacity(0.54))
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    // MARK: - Actions
+
+    private var actionButtons: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if isConfigured {
+                configuredActions
+            } else {
+                unconfiguredActions
+            }
+            roleActions
+        }
+    }
+
+    private var configuredActions: some View {
+        HStack(spacing: 8) {
+            cardButton("Edit", filled: false, action: onEdit)
+            cardButton("Remove", style: .destructive, action: onRemove)
+        }
+    }
+
+    private var unconfiguredActions: some View {
+        HStack(spacing: 8) {
+            cardButton("Configure", filled: true, action: onConfigure)
+        }
+    }
+
+    @ViewBuilder
+    private var roleActions: some View {
+        let showPrimary = !isPrimary && canSetPrimary
+        let showSecondary = !isSecondary && canSetSecondary
+
+        if showPrimary || showSecondary {
+            HStack(spacing: 8) {
+                if showPrimary {
+                    cardButton("Set as Primary", filled: true, action: onSetPrimary)
+                }
+                if showSecondary {
+                    cardButton("Set as Secondary", filled: true, action: onSetSecondary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Button Helpers
+
+    private enum ButtonStyle {
+        case normal
+        case destructive
+    }
+
+    private func cardButton(
+        _ title: String,
+        filled: Bool = false,
+        style: ButtonStyle = .normal,
+        action: @escaping () -> Void
+    ) -> some View {
+        let bg: Color
+        let fg: Color
+        let border: Color
+
+        switch style {
+        case .destructive:
+            bg = .white
+            fg = Color.red.opacity(0.7)
+            border = Color.red.opacity(0.2)
+        case .normal:
+            if filled {
+                bg = accentColor
+                fg = .white
+                border = .clear
+            } else {
+                bg = .white
+                fg = .black
+                border = Color.black.opacity(0.14)
+            }
+        }
+
+        return DayflowSurfaceButton(
+            action: action,
+            content: {
+                Text(title)
+                    .font(.custom("Nunito", size: 12))
+                    .fontWeight(.semibold)
+                    .frame(width: buttonTextWidth, alignment: .center)
+            },
+            background: bg,
+            foreground: fg,
+            borderColor: border,
+            cornerRadius: 7,
+            horizontalPadding: 10,
+            verticalPadding: 5,
+            showOverlayStroke: filled
+        )
+    }
+
+    private func cardButton(
+        _ title: String,
+        style: ButtonStyle,
+        action: @escaping () -> Void
+    ) -> some View {
+        cardButton(title, filled: false, style: style, action: action)
+    }
+}

--- a/Dayflow/Dayflow/Views/UI/Settings/ProviderConfigEditor.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/ProviderConfigEditor.swift
@@ -1,0 +1,269 @@
+//
+//  ProviderConfigEditor.swift
+//  Dayflow
+//
+//  Simple form-based editor for provider configuration
+//  Opens as a sheet instead of the full onboarding wizard
+//
+
+import SwiftUI
+
+struct ProviderConfigEditor: View {
+    let providerId: String  // canonical: "gemini", "ollama", "chatgpt_claude"
+    @ObservedObject var viewModel: ProvidersSettingsViewModel
+    let onDismiss: () -> Void
+
+    @State private var geminiAPIKey: String = ""
+    @State private var selectedCLITool: CLITool = .codex
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: true) {
+            VStack(alignment: .leading, spacing: 20) {
+                header
+                formContent
+                Spacer(minLength: 20)
+                bottomButtons
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(28)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .onAppear {
+            if providerId == "gemini" {
+                geminiAPIKey = KeychainManager.shared.retrieve(for: "gemini") ?? ""
+            }
+            if providerId == "chatgpt_claude" {
+                selectedCLITool = viewModel.preferredCLITool ?? .codex
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Edit \(providerName)")
+                    .font(.custom("Nunito", size: 18))
+                    .fontWeight(.semibold)
+                    .foregroundColor(.black.opacity(0.85))
+                Text("Update your configuration without re-running setup")
+                    .font(.custom("Nunito", size: 12))
+                    .foregroundColor(.black.opacity(0.55))
+            }
+            Spacer()
+            Button(action: onDismiss) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 20))
+                    .foregroundColor(.black.opacity(0.35))
+            }
+            .buttonStyle(.plain)
+            .pointingHandCursor()
+        }
+    }
+
+    // MARK: - Form
+
+    @ViewBuilder
+    private var formContent: some View {
+        switch providerId {
+        case "gemini":
+            geminiForm
+        case "ollama":
+            ollamaForm
+        case "chatgpt_claude":
+            chatCLIForm
+        default:
+            Text("Unknown provider")
+                .font(.custom("Nunito", size: 13))
+                .foregroundColor(.black.opacity(0.55))
+        }
+    }
+
+    // MARK: - Gemini
+
+    private var geminiForm: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            fieldGroup(label: "API Key") {
+                SecureField("Enter your Gemini API key", text: $geminiAPIKey)
+                    .font(.custom("Nunito", size: 13))
+                    .textFieldStyle(.plain)
+                    .padding(10)
+                    .background(Color.white)
+                    .cornerRadius(8)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.black.opacity(0.12), lineWidth: 1)
+                    )
+            }
+
+            fieldGroup(label: "Model Preference") {
+                Picker("Gemini model", selection: $viewModel.selectedGeminiModel) {
+                    ForEach(GeminiModel.allCases, id: \.self) { model in
+                        Text(model.displayName).tag(model)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .environment(\.colorScheme, .light)
+            }
+        }
+    }
+
+    // MARK: - Ollama
+
+    private var ollamaForm: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            fieldGroup(label: "Engine") {
+                Picker("Engine", selection: $viewModel.localEngine) {
+                    Text("Ollama").tag(LocalEngine.ollama)
+                    Text("LM Studio").tag(LocalEngine.lmstudio)
+                    Text("Custom").tag(LocalEngine.custom)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .environment(\.colorScheme, .light)
+            }
+
+            fieldGroup(label: "Base URL") {
+                TextField(viewModel.localEngine.defaultBaseURL, text: $viewModel.localBaseURL)
+                    .font(.custom("Nunito", size: 13))
+                    .textFieldStyle(.plain)
+                    .padding(10)
+                    .background(Color.white)
+                    .cornerRadius(8)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.black.opacity(0.12), lineWidth: 1)
+                    )
+            }
+
+            fieldGroup(label: "Model ID") {
+                TextField("e.g. qwen2.5vl:3b", text: $viewModel.localModelId)
+                    .font(.custom("Nunito", size: 13))
+                    .textFieldStyle(.plain)
+                    .padding(10)
+                    .background(Color.white)
+                    .cornerRadius(8)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.black.opacity(0.12), lineWidth: 1)
+                    )
+            }
+
+            fieldGroup(label: "API Key (optional)") {
+                SecureField("Leave blank if not required", text: $viewModel.localAPIKey)
+                    .font(.custom("Nunito", size: 13))
+                    .textFieldStyle(.plain)
+                    .padding(10)
+                    .background(Color.white)
+                    .cornerRadius(8)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.black.opacity(0.12), lineWidth: 1)
+                    )
+            }
+        }
+    }
+
+    // MARK: - ChatGPT / Claude
+
+    private var chatCLIForm: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            fieldGroup(label: "Preferred CLI Tool") {
+                Picker("CLI Tool", selection: $selectedCLITool) {
+                    ForEach(CLITool.allCases, id: \.self) { tool in
+                        Text(tool.displayName).tag(tool)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .environment(\.colorScheme, .light)
+            }
+
+            Text("Dayflow will use the selected CLI tool to generate timeline summaries.")
+                .font(.custom("Nunito", size: 12))
+                .foregroundColor(.black.opacity(0.55))
+        }
+    }
+
+    // MARK: - Shared Helpers
+
+    private func fieldGroup<Content: View>(label: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label)
+                .font(.custom("Nunito", size: 13))
+                .fontWeight(.semibold)
+                .foregroundColor(.black.opacity(0.65))
+            content()
+        }
+    }
+
+    // MARK: - Bottom Buttons
+
+    private var bottomButtons: some View {
+        HStack(spacing: 12) {
+            Spacer()
+            DayflowSurfaceButton(
+                action: onDismiss,
+                content: {
+                    Text("Cancel")
+                        .font(.custom("Nunito", size: 13))
+                        .fontWeight(.semibold)
+                },
+                background: .white,
+                foreground: .black,
+                borderColor: Color.black.opacity(0.15),
+                cornerRadius: 8,
+                horizontalPadding: 18,
+                verticalPadding: 10,
+                showOverlayStroke: false
+            )
+            DayflowSurfaceButton(
+                action: saveConfiguration,
+                content: {
+                    Text("Save")
+                        .font(.custom("Nunito", size: 13))
+                        .fontWeight(.semibold)
+                },
+                background: Color(red: 0.25, green: 0.17, blue: 0),
+                foreground: .white,
+                borderColor: .clear,
+                cornerRadius: 8,
+                horizontalPadding: 18,
+                verticalPadding: 10,
+                showOverlayStroke: true
+            )
+        }
+    }
+
+    // MARK: - Save
+
+    private func saveConfiguration() {
+        switch providerId {
+        case "gemini":
+            let trimmed = geminiAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                KeychainManager.shared.store(trimmed, for: "gemini")
+            }
+            viewModel.persistGeminiModelSelection(viewModel.selectedGeminiModel, source: "config_editor")
+        case "ollama":
+            viewModel.handleLocalTestCompletion()
+        case "chatgpt_claude":
+            UserDefaults.standard.set(selectedCLITool.rawValue, forKey: "chatCLIPreferredTool")
+            viewModel.preferredCLITool = selectedCLITool
+        default:
+            break
+        }
+        onDismiss()
+    }
+
+    private var providerName: String {
+        switch providerId {
+        case "gemini": return "Gemini"
+        case "ollama": return "Local (Ollama)"
+        case "chatgpt_claude": return "ChatGPT / Claude"
+        default: return providerId.capitalized
+        }
+    }
+}

--- a/Dayflow/Dayflow/Views/UI/Settings/SettingsProvidersTabView.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/SettingsProvidersTabView.swift
@@ -73,6 +73,7 @@ struct SettingsProvidersTabView: View {
                         }
                     }
                 }
+                .environment(\.colorScheme, .light)
             }
 
             // MARK: - Available Providers

--- a/Dayflow/Dayflow/Views/UI/Settings/SettingsProvidersTabView.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/SettingsProvidersTabView.swift
@@ -6,6 +6,7 @@ struct SettingsProvidersTabView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 28) {
+            // MARK: - Upgrade Banner
             if viewModel.currentProvider == "ollama", viewModel.showLocalModelUpgradeBanner {
                 LocalModelUpgradeBanner(
                     preset: .qwen3VL4B,
@@ -27,53 +28,17 @@ struct SettingsProvidersTabView: View {
                     .padding(.horizontal, 4)
             }
 
-            SettingsCard(title: "Current configuration", subtitle: "Active provider and runtime details") {
-                VStack(alignment: .leading, spacing: 14) {
-                    providerSummary
-                    DayflowSurfaceButton(
-                        action: { viewModel.editProviderConfiguration(viewModel.primaryRoutingProviderId) },
-                        content: {
-                            HStack(spacing: 8) {
-                                Image(systemName: "slider.horizontal.3")
-                                Text("Edit configuration")
-                                    .font(.custom("Nunito", size: 13))
-                            }
-                            .frame(minWidth: 160)
-                        },
-                        background: Color(red: 0.25, green: 0.17, blue: 0),
-                        foreground: .white,
-                        borderColor: .clear,
-                        cornerRadius: 8,
-                        horizontalPadding: 20,
-                        verticalPadding: 10,
-                        showOverlayStroke: true
-                    )
-                    if viewModel.currentProvider == "ollama" {
-                        DayflowSurfaceButton(
-                            action: { viewModel.isShowingLocalModelUpgradeSheet = true },
-                            content: {
-                                HStack(spacing: 6) {
-                                    Image(systemName: viewModel.usingRecommendedLocalModel ? "slider.horizontal.2.square" : "arrow.up.circle.fill")
-                                        .font(.system(size: 14))
-                                    Text(viewModel.usingRecommendedLocalModel ? "Manage local model" : "Upgrade local model")
-                                        .font(.custom("Nunito", size: 13))
-                                        .fontWeight(.semibold)
-                                }
-                                .frame(minWidth: 160)
-                            },
-                            background: Color.white,
-                            foreground: .black,
-                            borderColor: Color.black.opacity(0.15),
-                            cornerRadius: 8,
-                            horizontalPadding: 16,
-                            verticalPadding: 9,
-                            showOverlayStroke: false
-                        )
-                        .padding(.top, 6)
-                    }
-                }
+            // MARK: - Primary Provider
+            SettingsCard(title: "Primary provider", subtitle: "The provider Dayflow uses for timeline summaries") {
+                primaryProviderCard
             }
 
+            // MARK: - Backup Provider
+            SettingsCard(title: "Backup provider", subtitle: "Fallback when the primary is unavailable") {
+                backupProviderCard
+            }
+
+            // MARK: - Connection Health
             SettingsCard(title: "Connection health", subtitle: "Run a quick test for the primary provider") {
                 VStack(alignment: .leading, spacing: 16) {
                     Text(viewModel.connectionHealthLabel)
@@ -110,10 +75,16 @@ struct SettingsProvidersTabView: View {
                 }
             }
 
-            SettingsCard(title: "Failover routing", subtitle: "Choose primary and secondary providers") {
-                routingMatrix
+            // MARK: - Available Providers
+            SettingsCard(title: "Available providers", subtitle: "Configure and assign roles to providers") {
+                VStack(alignment: .leading, spacing: 10) {
+                    ForEach(viewModel.routingProviders, id: \.id) { provider in
+                        providerCard(for: provider)
+                    }
+                }
             }
 
+            // MARK: - Model Preference & Prompt Customization
             if viewModel.currentProvider == "gemini" {
                 SettingsCard(title: "Gemini model preference", subtitle: "Choose which Gemini model Dayflow should prioritize") {
                     GeminiModelSettingsCard(selectedModel: $viewModel.selectedGeminiModel) { model in
@@ -134,147 +105,129 @@ struct SettingsProvidersTabView: View {
                 }
             }
         }
-    }
-
-    private let routingAccentColor = Color(red: 0.25, green: 0.17, blue: 0)
-    private let routingButtonTextWidth: CGFloat = 120
-
-    private var routingMatrix: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            ForEach(viewModel.routingProviders, id: \.id) { provider in
-                routingProviderCard(provider)
+        .sheet(isPresented: Binding(
+            get: { viewModel.editingProvider != nil },
+            set: { if !$0 { viewModel.editingProvider = nil } }
+        )) {
+            if let providerId = viewModel.editingProvider {
+                ProviderConfigEditor(
+                    providerId: providerId,
+                    viewModel: viewModel,
+                    onDismiss: { viewModel.editingProvider = nil }
+                )
+                .frame(width: 480, height: 420)
+                .preferredColorScheme(.light)
             }
         }
     }
 
-    private func hasPrimaryAndSecondaryActions(
-        isPrimary: Bool,
-        isSecondary: Bool
-    ) -> Bool {
-        !isPrimary && !isSecondary
-    }
+    // MARK: - Primary Provider Card
 
     @ViewBuilder
-    private func primaryAndSecondaryActions(
-        provider: CompactProviderInfo,
-        isPrimary: Bool,
-        isSecondary: Bool,
-        canSetSecondary: Bool
-    ) -> some View {
-        if hasPrimaryAndSecondaryActions(isPrimary: isPrimary, isSecondary: isSecondary) {
-            HStack(spacing: 8) {
-                matrixActionButton("Set primary", filled: true) {
-                    viewModel.setPrimaryOrSetup(provider.id)
-                }
-                matrixActionButton("Set secondary", filled: true, enabled: canSetSecondary) {
-                    viewModel.setSecondaryOrSetup(provider.id)
+    private var primaryProviderCard: some View {
+        let primaryId = viewModel.primaryRoutingProviderId
+        if let provider = viewModel.routingProviders.first(where: { $0.id == primaryId }) {
+            VStack(alignment: .leading, spacing: 14) {
+                ProviderCardView(
+                    provider: provider,
+                    isPrimary: true,
+                    isSecondary: false,
+                    isConfigured: viewModel.isProviderConfigured(primaryId),
+                    statusDetail: viewModel.statusText(for: primaryId),
+                    canSetPrimary: false,
+                    canSetSecondary: false,
+                    onEdit: { viewModel.editingProvider = primaryId },
+                    onConfigure: { viewModel.beginProviderSetup(primaryId, role: .setupOnly) },
+                    onRemove: { viewModel.removeProviderConfiguration(primaryId) },
+                    onSetPrimary: {},
+                    onSetSecondary: {}
+                )
+
+                if viewModel.currentProvider == "ollama" {
+                    DayflowSurfaceButton(
+                        action: { viewModel.isShowingLocalModelUpgradeSheet = true },
+                        content: {
+                            HStack(spacing: 6) {
+                                Image(systemName: viewModel.usingRecommendedLocalModel ? "slider.horizontal.2.square" : "arrow.up.circle.fill")
+                                    .font(.system(size: 14))
+                                Text(viewModel.usingRecommendedLocalModel ? "Manage local model" : "Upgrade local model")
+                                    .font(.custom("Nunito", size: 13))
+                                    .fontWeight(.semibold)
+                            }
+                            .frame(minWidth: 160)
+                        },
+                        background: Color.white,
+                        foreground: .black,
+                        borderColor: Color.black.opacity(0.15),
+                        cornerRadius: 8,
+                        horizontalPadding: 16,
+                        verticalPadding: 9,
+                        showOverlayStroke: false
+                    )
+                    .padding(.top, 6)
                 }
             }
-        } else if !isPrimary {
-            HStack(spacing: 8) {
-                matrixActionButton("Set primary", filled: true) {
-                    viewModel.setPrimaryOrSetup(provider.id)
-                }
-            }
-        } else if !isSecondary {
-            HStack(spacing: 8) {
-                matrixActionButton("Set secondary", filled: true, enabled: canSetSecondary) {
-                    viewModel.setSecondaryOrSetup(provider.id)
-                }
+        } else {
+            Text("No primary provider configured")
+                .font(.custom("Nunito", size: 13))
+                .foregroundColor(.black.opacity(0.55))
+        }
+    }
+
+    // MARK: - Backup Provider Card
+
+    @ViewBuilder
+    private var backupProviderCard: some View {
+        if let backupId = viewModel.secondaryRoutingProviderId,
+           let provider = viewModel.routingProviders.first(where: { $0.id == backupId }) {
+            ProviderCardView(
+                provider: provider,
+                isPrimary: false,
+                isSecondary: true,
+                isConfigured: viewModel.isProviderConfigured(backupId),
+                statusDetail: viewModel.statusText(for: backupId),
+                canSetPrimary: viewModel.canAssignPrimary(backupId),
+                canSetSecondary: false,
+                onEdit: { viewModel.editingProvider = backupId },
+                onConfigure: { viewModel.beginProviderSetup(backupId, role: .setupOnly) },
+                onRemove: { viewModel.removeProviderConfiguration(backupId) },
+                onSetPrimary: { viewModel.setPrimaryOrSetup(backupId) },
+                onSetSecondary: {}
+            )
+        } else {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Not configured")
+                    .font(.custom("Nunito", size: 14))
+                    .foregroundColor(.black.opacity(0.55))
+                Text("Set a secondary provider in the Available Providers section below.")
+                    .font(.custom("Nunito", size: 12))
+                    .foregroundColor(.black.opacity(0.45))
             }
         }
     }
 
-    @ViewBuilder
-    private func routingProviderCard(_ provider: CompactProviderInfo) -> some View {
+    // MARK: - Provider Card Factory
+
+    private func providerCard(for provider: CompactProviderInfo) -> some View {
         let isConfigured = viewModel.isProviderConfigured(provider.id)
         let isPrimary = viewModel.primaryRoutingProviderId == provider.id
         let isSecondary = viewModel.isBackupProvider(provider.id)
         let canSetSecondary = viewModel.canAssignSecondary(provider.id) || !isConfigured
 
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 10) {
-                Text(provider.providerTableName)
-                    .font(.custom("Nunito", size: 15))
-                    .fontWeight(.semibold)
-                    .foregroundColor(.black.opacity(0.82))
-
-                Spacer()
-
-                if isPrimary {
-                    roleTag(text: "PRIMARY", type: .orange)
-                } else if isSecondary {
-                    roleTag(text: "SECONDARY", type: .blue)
-                } else if isConfigured {
-                    roleTag(text: "CONFIGURED", type: .green)
-                } else {
-                    roleTag(text: "NOT SET", type: .green)
-                }
-            }
-
-            Text(provider.summary)
-                .font(.custom("Nunito", size: 12))
-                .foregroundColor(.black.opacity(0.54))
-                .fixedSize(horizontal: false, vertical: true)
-
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 8) {
-                    if !isConfigured {
-                        matrixActionButton("Setup", filled: false) {
-                            viewModel.beginProviderSetup(provider.id, role: .setupOnly)
-                        }
-                    }
-
-                    matrixActionButton("Edit configuration", filled: false) {
-                        viewModel.editProviderConfiguration(provider.id)
-                    }
-                }
-
-                primaryAndSecondaryActions(
-                    provider: provider,
-                    isPrimary: isPrimary,
-                    isSecondary: isSecondary,
-                    canSetSecondary: canSetSecondary
-                )
-            }
-        }
-        .padding(14)
-        .background(Color.white.opacity(0.52))
-        .cornerRadius(10)
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(Color.black.opacity(0.06), lineWidth: 1)
+        return ProviderCardView(
+            provider: provider,
+            isPrimary: isPrimary,
+            isSecondary: isSecondary,
+            isConfigured: isConfigured,
+            statusDetail: isConfigured ? viewModel.statusText(for: provider.id) : nil,
+            canSetPrimary: !isPrimary && isConfigured,
+            canSetSecondary: !isSecondary && canSetSecondary,
+            onEdit: { viewModel.editingProvider = provider.id },
+            onConfigure: { viewModel.beginProviderSetup(provider.id, role: .setupOnly) },
+            onRemove: { viewModel.removeProviderConfiguration(provider.id) },
+            onSetPrimary: { viewModel.setPrimaryOrSetup(provider.id) },
+            onSetSecondary: { viewModel.setSecondaryOrSetup(provider.id) }
         )
-    }
-
-    private func matrixActionButton(
-        _ title: String,
-        filled: Bool,
-        enabled: Bool = true,
-        action: @escaping () -> Void
-    ) -> some View {
-        DayflowSurfaceButton(
-            action: action,
-            content: {
-                Text(title)
-                    .font(.custom("Nunito", size: 12))
-                    .fontWeight(.semibold)
-                    .frame(width: routingButtonTextWidth, alignment: .center)
-            },
-            background: filled ? routingAccentColor : Color.white,
-            foreground: filled ? .white : .black,
-            borderColor: filled ? .clear : Color.black.opacity(0.14),
-            cornerRadius: 7,
-            horizontalPadding: 10,
-            verticalPadding: 5,
-            showOverlayStroke: filled
-        )
-        .disabled(!enabled)
-        .opacity(enabled ? 1 : 0.45)
-    }
-
-    private func roleTag(text: String, type: BadgeType) -> some View {
-        BadgeView(text: text, type: type)
     }
 
     private var geminiPromptCustomizationView: some View {
@@ -507,69 +460,6 @@ struct SettingsProvidersTabView: View {
         }
     }
 
-    @ViewBuilder
-    private var providerSummary: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            summaryRoleRow(
-                label: "Primary provider",
-                value: viewModel.providerDisplayName(viewModel.primaryRoutingProviderId),
-                roleText: "PRIMARY",
-                roleType: .orange
-            )
-            if let backupProvider = viewModel.secondaryRoutingProviderId {
-                summaryRoleRow(
-                    label: "Secondary provider",
-                    value: viewModel.providerDisplayName(backupProvider),
-                    roleText: "SECONDARY",
-                    roleType: .blue
-                )
-            } else {
-                summaryRow(label: "Secondary provider", value: "Not configured")
-            }
-
-            switch viewModel.currentProvider {
-            case "ollama":
-                summaryRow(label: "Engine", value: viewModel.localEngine.displayName)
-                summaryRow(label: "Model", value: viewModel.localModelId.isEmpty ? "Not configured" : viewModel.localModelId)
-                summaryRow(label: "Endpoint", value: viewModel.localBaseURL)
-                let hasKey = !viewModel.localAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                summaryRow(label: "API key", value: hasKey ? "Stored in UserDefaults" : "Not set")
-            case "gemini":
-                summaryRow(label: "Model preference", value: viewModel.selectedGeminiModel.displayName)
-                summaryRow(label: "API key", value: KeychainManager.shared.retrieve(for: "gemini") != nil ? "Stored safely in Keychain" : "Not set")
-            case "chatgpt_claude":
-                summaryRow(label: "CLI preference", value: viewModel.chatCLIStatusLabel())
-                summaryRow(label: "Status", value: "Use Edit configuration to re-run CLI checks")
-            default:
-                summaryRow(label: "Status", value: "Coming soon")
-            }
-        }
-    }
-
-    private func summaryRoleRow(label: String, value: String, roleText: String, roleType: BadgeType) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
-            Text(label)
-                .font(.custom("Nunito", size: 13))
-                .foregroundColor(.black.opacity(0.55))
-                .frame(width: 150, alignment: .leading)
-            Text(value)
-                .font(.custom("Nunito", size: 14))
-                .foregroundColor(.black.opacity(0.78))
-            roleTag(text: roleText, type: roleType)
-        }
-    }
-
-    private func summaryRow(label: String, value: String) -> some View {
-        HStack(alignment: .firstTextBaseline) {
-            Text(label)
-                .font(.custom("Nunito", size: 13))
-                .foregroundColor(.black.opacity(0.55))
-                .frame(width: 150, alignment: .leading)
-            Text(value)
-                .font(.custom("Nunito", size: 14))
-                .foregroundColor(.black.opacity(0.78))
-        }
-    }
 }
 
 private struct LocalModelUpgradeBanner: View {

--- a/Dayflow/Dayflow/Views/UI/SettingsView.swift
+++ b/Dayflow/Dayflow/Views/UI/SettingsView.swift
@@ -106,8 +106,12 @@ struct SettingsView: View {
                     selectedTab = .providers
                 }
             }
+            // Refresh provider state when window reappears (fixes stale defaults
+            // after close-without-quit, where @StateObject may be recreated).
+            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in
+                providersViewModel.refreshFromPersistence()
+            }
     }
-
     private var mainContent: some View {
         HStack(alignment: .top, spacing: 32) {
             sidebar


### PR DESCRIPTION
## Summary

Overhauls the Settings → Providers tab with a card-based UI and fixes several bugs related to window lifecycle, onboarding state, and macOS fullscreen behavior.

## Changes

### Settings Providers Tab Revamp
- **Card-based provider management** — Replaced the multi-step onboarding-style UI with a clean card layout showing Primary Provider, Backup Provider, Connection Health, and Available Providers at a glance.
- **New `ProviderCardView`** — Compact, reusable card component with provider icon, name, status badge, summary, and contextual action buttons (Configure / Set as Primary / Set as Backup / Remove).
- **New `ProviderConfigEditor`** — Sheet-based form editor for each provider type (Gemini, Ollama, ChatGPT/Claude), replacing the wizard flow for configuration changes.
- **Inline model & prompt customization** — Model Preference and Prompt Customization sections are now directly accessible within the Providers tab.

### Bug Fixes
- **Stale settings on window reopen** — Provider state now refreshes from UserDefaults/Keychain when the settings window regains focus, fixing incorrect defaults after soft-quit/reopen cycles. (`SettingsView.swift`, `ProvidersSettingsViewModel.swift`)
- **Premature onboarding persistence** — Setup wizard no longer writes partial config to UserDefaults/Keychain during intermediate steps; only persists on final save. (`LLMProviderSetupView.swift`)
- **Timeline cards disappearing** — Activities and review count now refresh when the app becomes active, fixing blank timeline after wake/reopen. (`Layout.swift`)
- **Menu bar popover not showing in fullscreen** — Popover window now uses `canJoinAllSpaces`, `moveToActiveSpace`, and `fullScreenAuxiliary` collection behaviors so it appears over fullscreen apps. (`StatusBarController.swift`)
- **Dark mode color bleed in connection health card** — Forced light color scheme on connection health test views to prevent `.roundedBorder` text fields from rendering with dark backgrounds. (`SettingsProvidersTabView.swift`)

## Files Changed (8 files, +653 / -253)

| File | Change |
|------|--------|
| `ProviderCardView.swift` | **New** — Reusable provider card component |
| `ProviderConfigEditor.swift` | **New** — Sheet-based provider configuration editor |
| `SettingsProvidersTabView.swift` | **Rewritten** — Card-based layout replacing wizard flow |
| `ProvidersSettingsViewModel.swift` | **Modified** — Added refresh, editing state, remove provider |
| `SettingsView.swift` | **Modified** — Window focus triggers provider refresh |
| `LLMProviderSetupView.swift` | **Modified** — Removed premature persistence in onboarding |
| `Layout.swift` | **Modified** — Refresh timeline on app activation |
| `StatusBarController.swift` | **Modified** — Fullscreen-compatible popover behavior |

## Testing

- Built successfully with `xcodebuild` (Debug, no code signing)
- Manual testing recommended for: provider card interactions, config editor sheet, window reopen state, fullscreen menu bar popover, timeline refresh after sleep/wake