### PR TITLE
core(notifications): add auto-resume recording alerts

### DIFF
--- a/Dayflow/Dayflow/App/PauseManager.swift
+++ b/Dayflow/Dayflow/App/PauseManager.swift
@@ -98,6 +98,7 @@ final class PauseManager: ObservableObject {
   func pause(for duration: PauseDuration, source: PauseSource) {
     // Stop any existing timer
     stopTimer()
+    RecordingResumeNotificationCoordinator.shared.clearPendingAutoResume()
 
     // Store for analytics
     currentPauseDuration = duration
@@ -135,6 +136,13 @@ final class PauseManager: ObservableObject {
     pauseEndTime = nil
     isPausedIndefinitely = false
     currentPauseDuration = nil
+
+    switch source {
+    case .timerExpired, .wakeFromSleep:
+      RecordingResumeNotificationCoordinator.shared.markPendingAutoResume(source: source)
+    case .userClickedMenuBar, .userClickedMainApp:
+      RecordingResumeNotificationCoordinator.shared.clearPendingAutoResume()
+    }
 
     // Start recording
     AppState.shared.isRecording = true

--- a/Dayflow/Dayflow/Core/Notifications/NotificationService.swift
+++ b/Dayflow/Dayflow/Core/Notifications/NotificationService.swift
@@ -10,6 +10,16 @@ import AppKit
 import Foundation
 @preconcurrency import UserNotifications
 
+enum NotificationPermissionState: Equatable {
+  case notDetermined
+  case denied
+  case authorized
+
+  var isAuthorized: Bool {
+    self == .authorized
+  }
+}
+
 @MainActor
 final class NotificationService: NSObject, ObservableObject {
   static let shared = NotificationService()
@@ -17,6 +27,7 @@ final class NotificationService: NSObject, ObservableObject {
   private let center = UNUserNotificationCenter.current()
 
   @Published private(set) var permissionGranted: Bool = false
+  @Published private(set) var permissionState: NotificationPermissionState = .notDetermined
 
   override private init() {
     super.init()
@@ -30,7 +41,7 @@ final class NotificationService: NSObject, ObservableObject {
 
     // Check current permission status
     Task {
-      await checkPermissionStatus()
+      await refreshPermissionStatus()
 
       // Reschedule if reminders are enabled
       if NotificationPreferences.isEnabled {
@@ -44,14 +55,34 @@ final class NotificationService: NSObject, ObservableObject {
   func requestPermission() async -> Bool {
     do {
       let granted = try await center.requestAuthorization(options: [.alert, .sound, .badge])
-      await MainActor.run {
-        self.permissionGranted = granted
-      }
+      _ = await refreshPermissionStatus()
       print("[NotificationService] requestPermission granted=\(granted)")
       return granted
     } catch {
       print("[NotificationService] Permission request failed: \(error)")
       return false
+    }
+  }
+
+  @discardableResult
+  func refreshPermissionStatus() async -> NotificationPermissionState {
+    let settings = await center.notificationSettings()
+    let state = Self.permissionState(for: settings)
+    permissionState = state
+    permissionGranted = state.isAuthorized
+    return state
+  }
+
+  func openNotificationSettings() {
+    let candidateURLs = [
+      "x-apple.systempreferences:com.apple.Notifications-Settings.extension",
+      "x-apple.systempreferences:com.apple.preference.notifications",
+    ]
+
+    for candidate in candidateURLs {
+      if let url = URL(string: candidate), NSWorkspace.shared.open(url) {
+        return
+      }
     }
   }
 
@@ -166,14 +197,25 @@ final class NotificationService: NSObject, ObservableObject {
     }
   }
 
-  // MARK: - Private Methods
+  func scheduleRecordingResumedNotification(source: ResumeSource) {
+    Task {
+      let settings = await center.notificationSettings()
+      let permissionState = Self.permissionState(for: settings)
 
-  private func checkPermissionStatus() async {
-    let settings = await center.notificationSettings()
-    await MainActor.run {
-      self.permissionGranted = Self.canScheduleNotifications(for: settings.authorizationStatus)
+      guard permissionState.isAuthorized else {
+        print(
+          "[NotificationService] Skipping recording resumed notification: "
+            + "source=\(source.rawValue) permission_status=\(Self.authorizationStatusName(settings.authorizationStatus)) "
+            + "alert_setting=\(Self.notificationSettingName(settings.alertSetting))"
+        )
+        return
+      }
+
+      enqueueRecordingResumedNotification(source: source)
     }
   }
+
+  // MARK: - Private Methods
 
   private func enqueueDailyRecapReadyNotification(
     forDay day: String, settings: UNNotificationSettings
@@ -234,6 +276,34 @@ final class NotificationService: NSObject, ObservableObject {
     }
   }
 
+  private func enqueueRecordingResumedNotification(source: ResumeSource) {
+    let identifier = "recording.resumed"
+    let content = UNMutableNotificationContent()
+    content.title = "Recording resumed"
+    content.body = recordingResumedBody(for: source)
+    content.sound = .default
+    content.categoryIdentifier = "recording_resumed"
+    content.userInfo = ["source": source.rawValue]
+
+    let request = UNNotificationRequest(
+      identifier: "\(identifier).\(source.rawValue).\(Date().timeIntervalSince1970)",
+      content: content,
+      trigger: nil
+    )
+
+    center.add(request) { error in
+      if let error {
+        print(
+          "[NotificationService] Failed to schedule recording resumed notification: \(error)")
+        return
+      }
+      print(
+        "[NotificationService] Scheduled recording resumed notification "
+          + "source=\(source.rawValue)"
+      )
+    }
+  }
+
   private static func authorizationStatusName(_ status: UNAuthorizationStatus) -> String {
     switch status {
     case .notDetermined:
@@ -258,6 +328,20 @@ final class NotificationService: NSObject, ObservableObject {
     }
   }
 
+  private static func permissionState(for settings: UNNotificationSettings) -> NotificationPermissionState
+  {
+    switch settings.authorizationStatus {
+    case .authorized, .provisional:
+      return settings.alertSetting == .enabled ? .authorized : .denied
+    case .denied:
+      return .denied
+    case .notDetermined:
+      return .notDetermined
+    @unknown default:
+      return .notDetermined
+    }
+  }
+
   private static func notificationSettingName(_ setting: UNNotificationSetting) -> String {
     switch setting {
     case .notSupported:
@@ -268,6 +352,17 @@ final class NotificationService: NSObject, ObservableObject {
       return "enabled"
     @unknown default:
       return "unknown"
+    }
+  }
+
+  private func recordingResumedBody(for source: ResumeSource) -> String {
+    switch source {
+    case .timerExpired:
+      return "Dayflow resumed recording after your pause ended."
+    case .wakeFromSleep:
+      return "Dayflow resumed recording after your Mac woke up."
+    case .userClickedMenuBar, .userClickedMainApp:
+      return "Dayflow is recording again."
     }
   }
 
@@ -333,8 +428,9 @@ extension NotificationService: UNUserNotificationCenterDelegate {
 
     let isJournalNotification = identifier.hasPrefix("journal.")
     let isDailyRecapNotification = identifier.hasPrefix("daily.")
+    let isRecordingNotification = identifier.hasPrefix("recording.")
 
-    guard isJournalNotification || isDailyRecapNotification else {
+    guard isJournalNotification || isDailyRecapNotification || isRecordingNotification else {
       completionHandler()
       return
     }
@@ -347,7 +443,7 @@ extension NotificationService: UNUserNotificationCenterDelegate {
         activateAppForNotificationTap()
         print(
           "[NotificationService] didReceive journal notification handled identifier=\(identifier)")
-      } else {
+      } else if isDailyRecapNotification {
         AppDelegate.pendingNavigationToDailyDay = day
         AppDelegate.pendingNavigationToJournal = false
 
@@ -373,6 +469,9 @@ extension NotificationService: UNUserNotificationCenterDelegate {
           print("[NotificationService] didReceive daily notification navigation target_day=unknown")
         }
 
+        activateAppForNotificationTap()
+      } else {
+        print("[NotificationService] didReceive recording notification tap identifier=\(identifier)")
         activateAppForNotificationTap()
       }
     }
@@ -402,6 +501,12 @@ extension NotificationService: UNUserNotificationCenterDelegate {
     }
 
     if identifier.hasPrefix("daily.") {
+      print("[NotificationService] willPresent options=banner,sound identifier=\(identifier)")
+      completionHandler([.banner, .sound])
+      return
+    }
+
+    if identifier.hasPrefix("recording.") {
       print("[NotificationService] willPresent options=banner,sound identifier=\(identifier)")
       completionHandler([.banner, .sound])
       return

--- a/Dayflow/Dayflow/Core/Notifications/RecordingResumeNotificationCoordinator.swift
+++ b/Dayflow/Dayflow/Core/Notifications/RecordingResumeNotificationCoordinator.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+@MainActor
+final class RecordingResumeNotificationCoordinator {
+  static let shared = RecordingResumeNotificationCoordinator()
+
+  private var pendingAutoResumeSource: ResumeSource?
+
+  private init() {}
+
+  func markPendingAutoResume(source: ResumeSource) {
+    pendingAutoResumeSource = source
+  }
+
+  func consumePendingAutoResumeSource() -> ResumeSource? {
+    let source = pendingAutoResumeSource
+    pendingAutoResumeSource = nil
+    return source
+  }
+
+  func clearPendingAutoResume() {
+    pendingAutoResumeSource = nil
+  }
+}

--- a/Dayflow/Dayflow/Core/Recording/ScreenRecorder.swift
+++ b/Dayflow/Dayflow/Core/Recording/ScreenRecorder.swift
@@ -115,6 +115,12 @@ final class ScreenRecorder: NSObject, @unchecked Sendable {
           guard let self else { return }
           self.wantsRecording = rec
 
+          if !rec {
+            Task { @MainActor in
+              RecordingResumeNotificationCoordinator.shared.clearPendingAutoResume()
+            }
+          }
+
           // Clear paused state when user disables recording
           if !rec && self.state == .paused {
             self.transition(to: .idle, context: "user disabled recording")
@@ -260,6 +266,14 @@ final class ScreenRecorder: NSObject, @unchecked Sendable {
         }
         self.startCaptureTimer()
         self.transition(to: .capturing, context: "capture started")
+
+        Task { @MainActor in
+          if let source =
+            RecordingResumeNotificationCoordinator.shared.consumePendingAutoResumeSource()
+          {
+            NotificationService.shared.scheduleRecordingResumedNotification(source: source)
+          }
+        }
 
         // Take first screenshot immediately
         Task { await self.captureScreenshot() }

--- a/Dayflow/Dayflow/Views/UI/Settings/OtherSettingsViewModel.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/OtherSettingsViewModel.swift
@@ -24,6 +24,8 @@ final class OtherSettingsViewModel: ObservableObject {
       UserDefaults.standard.set(showTimelineAppIcons, forKey: "showTimelineAppIcons")
     }
   }
+  @Published private(set) var notificationPermissionState: NotificationPermissionState = .notDetermined
+  @Published private(set) var isUpdatingNotificationPermission = false
   @Published var outputLanguageOverride: String
   @Published var isOutputLanguageOverrideSaved: Bool = true
 
@@ -70,6 +72,27 @@ final class OtherSettingsViewModel: ObservableObject {
 
   func refreshAnalyticsState() {
     analyticsEnabled = AnalyticsService.shared.isOptedIn
+  }
+
+  func refreshNotificationPermissionState() {
+    Task { @MainActor in
+      notificationPermissionState = await NotificationService.shared.refreshPermissionStatus()
+    }
+  }
+
+  func requestNotificationPermission() {
+    guard !isUpdatingNotificationPermission else { return }
+    isUpdatingNotificationPermission = true
+
+    Task { @MainActor in
+      _ = await NotificationService.shared.requestPermission()
+      notificationPermissionState = await NotificationService.shared.refreshPermissionStatus()
+      isUpdatingNotificationPermission = false
+    }
+  }
+
+  func openNotificationSettings() {
+    NotificationService.shared.openNotificationSettings()
   }
 
   func exportTimelineRange() {

--- a/Dayflow/Dayflow/Views/UI/Settings/SettingsOtherTabView.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/SettingsOtherTabView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct SettingsOtherTabView: View {
@@ -59,6 +60,8 @@ struct SettingsOtherTabView: View {
           Text("When off, timeline cards won't show app or website icons.")
             .font(.custom("Nunito", size: 11.5))
             .foregroundColor(.black.opacity(0.5))
+
+          notificationPermissionSection
 
           VStack(alignment: .leading, spacing: 8) {
             Text("Output language override")
@@ -132,6 +135,128 @@ struct SettingsOtherTabView: View {
           .foregroundColor(.black.opacity(0.45))
         }
       }
+    }
+    .onAppear {
+      viewModel.refreshNotificationPermissionState()
+    }
+    .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))
+    { _ in
+      viewModel.refreshNotificationPermissionState()
+    }
+  }
+
+  private var notificationPermissionSection: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("Notifications")
+        .font(.custom("Nunito", size: 13))
+        .foregroundColor(.black.opacity(0.7))
+
+      HStack(alignment: .center, spacing: 10) {
+        notificationPermissionBadge
+
+        if let actionTitle = notificationPermissionActionTitle {
+          DayflowSurfaceButton(
+            action: notificationPermissionAction,
+            content: {
+              HStack(spacing: 8) {
+                if viewModel.isUpdatingNotificationPermission {
+                  ProgressView()
+                    .scaleEffect(0.75)
+                } else {
+                  Image(systemName: notificationPermissionActionSymbol)
+                    .font(.system(size: 12, weight: .semibold))
+                }
+
+                Text(actionTitle)
+                  .font(.custom("Nunito", size: 12))
+              }
+              .padding(.horizontal, 2)
+            },
+            background: Color.white,
+            foreground: Color(red: 0.25, green: 0.17, blue: 0),
+            borderColor: Color(hex: "FFE0A5"),
+            cornerRadius: 8,
+            horizontalPadding: 12,
+            verticalPadding: 7,
+            showOverlayStroke: true
+          )
+          .disabled(viewModel.isUpdatingNotificationPermission)
+        }
+      }
+
+      Text(
+        "Automatic recording resumes can send a system notification when access is enabled. Manual Resume never sends a notification."
+      )
+      .font(.custom("Nunito", size: 11.5))
+      .foregroundColor(.black.opacity(0.5))
+      .fixedSize(horizontal: false, vertical: true)
+    }
+  }
+
+  private var notificationPermissionBadge: some View {
+    Text(notificationPermissionStatusTitle)
+      .font(.custom("Nunito", size: 11.5))
+      .foregroundColor(notificationPermissionStatusColor)
+      .padding(.horizontal, 10)
+      .padding(.vertical, 6)
+      .background(notificationPermissionStatusColor.opacity(0.10))
+      .overlay(
+        Capsule()
+          .strokeBorder(notificationPermissionStatusColor.opacity(0.25), lineWidth: 1)
+      )
+      .clipShape(Capsule())
+  }
+
+  private var notificationPermissionStatusTitle: String {
+    switch viewModel.notificationPermissionState {
+    case .authorized:
+      return "Enabled"
+    case .notDetermined:
+      return "Not enabled"
+    case .denied:
+      return "Denied in System Settings"
+    }
+  }
+
+  private var notificationPermissionStatusColor: Color {
+    switch viewModel.notificationPermissionState {
+    case .authorized:
+      return Color(red: 0.14, green: 0.53, blue: 0.23)
+    case .notDetermined:
+      return Color(red: 0.53, green: 0.42, blue: 0.15)
+    case .denied:
+      return Color(hex: "C44D3A")
+    }
+  }
+
+  private var notificationPermissionActionTitle: String? {
+    switch viewModel.notificationPermissionState {
+    case .authorized:
+      return nil
+    case .notDetermined:
+      return "Enable notifications"
+    case .denied:
+      return "Open System Settings"
+    }
+  }
+
+  private var notificationPermissionActionSymbol: String {
+    switch viewModel.notificationPermissionState {
+    case .authorized, .notDetermined:
+      return "bell.badge"
+    case .denied:
+      return "arrow.up.right.square"
+    }
+  }
+
+  private func notificationPermissionAction() {
+    switch viewModel.notificationPermissionState {
+    case .authorized:
+      break
+    case .notDetermined:
+      viewModel.requestNotificationPermission()
+    case .denied:
+      viewModel.openNotificationSettings()
     }
   }
 }


### PR DESCRIPTION
  ## Summary

  Add system notifications for automatic recording resumes.

  This also adds a notification permission control in Settings, so users can enable notifications explicitly from the app instead of being prompted by resume actions.

  ## Changes

  - add notification permission status and actions to `Settings > Other`
  - allow requesting notification permission from Settings
  - add shortcut to open macOS notification settings when alerts are denied/disabled
  - send a local notification only for automatic recording resume
  - do not notify on manual resume
  - only treat notifications as enabled when alerts/banners are actually available
  - only send the resume notification after the recorder successfully re-enters capture
