### PR TITLE
feat(recording): capture all displays simultaneously

### DIFF
--- a/Dayflow/Dayflow/Core/Recording/ScreenRecorder.swift
+++ b/Dayflow/Dayflow/Core/Recording/ScreenRecorder.swift
@@ -332,7 +332,20 @@ final class ScreenRecorder: NSObject, @unchecked Sendable {
       return
     }
 
-    let displays = cachedDisplays.isEmpty ? [cachedDisplay].compactMap { $0 } : cachedDisplays
+    // Refresh the display list every tick to pick up newly connected displays
+    let displays: [SCDisplay]
+    do {
+      let content = try await SCShareableContent.excludingDesktopWindows(
+        false, onScreenWindowsOnly: true)
+      cachedContent = content
+      cachedDisplays = content.displays
+      displays = content.displays
+    } catch {
+      // Fall back to cached displays
+      displays = cachedDisplays.isEmpty ? [cachedDisplay].compactMap { $0 } : cachedDisplays
+      dbg("Failed to refresh displays, using cached: \(error.localizedDescription)")
+    }
+
     guard !displays.isEmpty else {
       dbg("captureScreenshot skipped - no displays")
       return

--- a/Dayflow/Dayflow/Core/Recording/ScreenRecorder.swift
+++ b/Dayflow/Dayflow/Core/Recording/ScreenRecorder.swift
@@ -160,6 +160,7 @@ final class ScreenRecorder: NSObject, @unchecked Sendable {
   // ScreenCaptureKit objects (refreshed on each capture cycle)
   private var cachedContent: SCShareableContent?
   private var cachedDisplay: SCDisplay?
+  private var cachedDisplays: [SCDisplay] = []  // All displays for multi-display capture
 
   // MARK: - State Transitions
 
@@ -209,6 +210,7 @@ final class ScreenRecorder: NSObject, @unchecked Sendable {
       self.stopCaptureTimer()
       self.cachedContent = nil
       self.cachedDisplay = nil
+      self.cachedDisplays = []
       self.currentDisplayID = nil
 
       if self.state != .paused {
@@ -246,10 +248,11 @@ final class ScreenRecorder: NSObject, @unchecked Sendable {
       }
 
       cachedDisplay = display
+      cachedDisplays = content.displays
       currentDisplayID = display.displayID
       requestedDisplayID = nil
 
-      dbg("Setup complete - display \(display.displayID) (\(display.width)x\(display.height))")
+      dbg("Setup complete - \(content.displays.count) display(s), active: \(display.displayID) (\(display.width)x\(display.height))")
 
       // 3. Start capture timer
       q.async { [weak self] in
@@ -328,64 +331,68 @@ final class ScreenRecorder: NSObject, @unchecked Sendable {
       dbg("captureScreenshot skipped - state: \(state.description)")
       return
     }
-    guard let display = cachedDisplay else {
-      dbg("captureScreenshot skipped - no display")
+
+    let displays = cachedDisplays.isEmpty ? [cachedDisplay].compactMap { $0 } : cachedDisplays
+    guard !displays.isEmpty else {
+      dbg("captureScreenshot skipped - no displays")
       return
     }
 
     let captureTime = Date()
     let idleSecondsAtCapture = InputIdleSnapshot.currentIdleSeconds()
 
-    do {
-      // 1. Create content filter for the display
-      let filter = SCContentFilter(display: display, excludingWindows: [])
+    for display in displays {
+      do {
+        // 1. Create content filter for the display
+        let filter = SCContentFilter(display: display, excludingWindows: [])
 
-      // 2. Configure screenshot
-      let config = SCStreamConfiguration()
+        // 2. Configure screenshot
+        let config = SCStreamConfiguration()
 
-      // Calculate dimensions to maintain aspect ratio at ~1080p
-      let aspectRatio = Double(display.width) / Double(display.height)
-      var targetWidth = Int(Double(Config.targetHeight) * aspectRatio)
-      if targetWidth % 2 != 0 { targetWidth += 1 }  // Ensure even
-      var targetHeight = Int(Config.targetHeight)
-      if targetHeight % 2 != 0 { targetHeight += 1 }
+        // Calculate dimensions to maintain aspect ratio at ~1080p
+        let aspectRatio = Double(display.width) / Double(display.height)
+        var targetWidth = Int(Double(Config.targetHeight) * aspectRatio)
+        if targetWidth % 2 != 0 { targetWidth += 1 }  // Ensure even
+        var targetHeight = Int(Config.targetHeight)
+        if targetHeight % 2 != 0 { targetHeight += 1 }
 
-      config.width = targetWidth
-      config.height = targetHeight
-      config.scalesToFit = true
-      config.showsCursor = true
+        config.width = targetWidth
+        config.height = targetHeight
+        config.scalesToFit = true
+        config.showsCursor = true
 
-      // 3. Capture screenshot
-      let image = try await SCScreenshotManager.captureImage(
-        contentFilter: filter,
-        configuration: config
-      )
+        // 3. Capture screenshot
+        let image = try await SCScreenshotManager.captureImage(
+          contentFilter: filter,
+          configuration: config
+        )
 
-      // 4. Convert to JPEG
-      guard let jpegData = jpegData(from: image, quality: Config.jpegQuality) else {
-        throw ScreenRecorderError.imageConversionFailed
-      }
+        // 4. Convert to JPEG
+        guard let jpegData = jpegData(from: image, quality: Config.jpegQuality) else {
+          throw ScreenRecorderError.imageConversionFailed
+        }
 
-      // 5. Save to file
-      let fileURL = StorageManager.shared.nextScreenshotURL()
-      try jpegData.write(to: fileURL)
+        // 5. Save to file
+        let fileURL = StorageManager.shared.nextScreenshotURL()
+        try jpegData.write(to: fileURL)
 
-      // 6. Register in database
-      _ = StorageManager.shared.saveScreenshot(
-        url: fileURL,
-        capturedAt: captureTime,
-        idleSecondsAtCapture: idleSecondsAtCapture
-      )
+        // 6. Register in database
+        _ = StorageManager.shared.saveScreenshot(
+          url: fileURL,
+          capturedAt: captureTime,
+          idleSecondsAtCapture: idleSecondsAtCapture
+        )
 
-      dbg("📸 Screenshot saved: \(fileURL.lastPathComponent) (\(jpegData.count / 1024)KB)")
+        dbg("📸 Screenshot saved: \(fileURL.lastPathComponent) display \(display.displayID) (\(jpegData.count / 1024)KB)")
 
-    } catch {
-      dbg("❌ Screenshot capture failed: \(error.localizedDescription)")
+      } catch {
+        dbg("❌ Screenshot capture failed for display \(display.displayID): \(error.localizedDescription)")
 
-      // If display became unavailable, try to refresh
-      if (error as NSError).domain == SCStreamErrorDomain {
-        dbg("SCStream error - will refresh display on next capture")
-        Task { await refreshDisplay() }
+        // If display became unavailable, try to refresh
+        if (error as NSError).domain == SCStreamErrorDomain {
+          dbg("SCStream error on display \(display.displayID) - will refresh")
+          Task { await refreshDisplay() }
+        }
       }
     }
   }
@@ -395,6 +402,7 @@ final class ScreenRecorder: NSObject, @unchecked Sendable {
       let content = try await SCShareableContent.excludingDesktopWindows(
         false, onScreenWindowsOnly: true)
       cachedContent = content
+      cachedDisplays = content.displays
 
       // Prefer requested display (from active display tracking) over current
       let targetID = requestedDisplayID ?? currentDisplayID
@@ -410,6 +418,7 @@ final class ScreenRecorder: NSObject, @unchecked Sendable {
         cachedDisplay = first
         currentDisplayID = first.displayID
       }
+      dbg("Refreshed displays: \(content.displays.count) available")
     } catch {
       dbg("Failed to refresh display: \(error)")
     }


### PR DESCRIPTION
## Summary

- **Captures all connected displays** on every screenshot tick instead of only the display under the mouse cursor
- Each display produces its own JPEG per interval, using the existing `nextScreenshotURL()` timestamp-based naming (millisecond precision avoids collisions)
- The `ActiveDisplayTracker` is preserved so the "active" display metadata still reflects where the user is working
- No database schema changes needed - each screenshot is a separate row as before

## Motivation

On multi-monitor setups, the current behavior only records whichever screen the mouse is on. This means significant portions of the workday (code on one screen, browser/docs on the other) go unrecorded and don't appear in the timeline.

## Changes

**`ScreenRecorder.swift`** (only file changed):
- Added `cachedDisplays` array alongside existing `cachedDisplay`
- `setupCapture()` now caches all displays from `SCShareableContent`
- `captureScreenshot()` iterates over all displays instead of just one
- `refreshDisplay()` updates the full display list
- `stop()` clears the display array

## Storage impact

Screenshot count scales linearly with display count (2x for dual monitors). The existing `storageLimitRecordingsBytes` setting still applies and will naturally limit total storage.

## Test plan

- [ ] Build and run with single monitor - verify behavior unchanged
- [ ] Connect second monitor - verify both screens produce screenshots
- [ ] Disconnect monitor mid-recording - verify no crash, graceful fallback
- [ ] Check storage usage stays within configured limits

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)