### PR TITLE
fix: reduce CPU usage from screenshot JPEG encoding and DateFormatter allocations

### DIFF
--- a/Dayflow/Dayflow/Core/Recording/ScreenRecorder.swift
+++ b/Dayflow/Dayflow/Core/Recording/ScreenRecorder.swift
@@ -11,6 +11,7 @@ import AppKit
 import Combine
 import CoreGraphics
 import Foundation
+import ImageIO
 @preconcurrency import ScreenCaptureKit
 import Sentry
 
@@ -418,23 +419,18 @@ final class ScreenRecorder: NSObject, @unchecked Sendable {
   // MARK: - Image Conversion
 
   private func jpegData(from cgImage: CGImage, quality: CGFloat) -> Data? {
-    let nsImage = NSImage(
-      cgImage: cgImage,
-      size: NSSize(
-        width: cgImage.width,
-        height: cgImage.height
-      ))
-
-    guard let tiffData = nsImage.tiffRepresentation,
-      let bitmap = NSBitmapImageRep(data: tiffData)
+    let data = NSMutableData()
+    guard
+      let destination = CGImageDestinationCreateWithData(
+        data as CFMutableData, "public.jpeg" as CFString, 1, nil)
     else {
       return nil
     }
-
-    return bitmap.representation(
-      using: .jpeg,
-      properties: [.compressionFactor: quality]
-    )
+    CGImageDestinationAddImage(
+      destination, cgImage,
+      [kCGImageDestinationLossyCompressionQuality: quality] as CFDictionary)
+    guard CGImageDestinationFinalize(destination) else { return nil }
+    return data as Data
   }
 
   // MARK: - Display Change Handling

--- a/Dayflow/Dayflow/Core/Recording/VideoProcessingService.swift
+++ b/Dayflow/Dayflow/Core/Recording/VideoProcessingService.swift
@@ -57,6 +57,18 @@ actor VideoProcessingService {
   private let persistentTimelapsesRootURL: URL
   private let colorSpace = CGColorSpaceCreateDeviceRGB()
 
+  // Cached DateFormatters to avoid repeated allocation
+  private let dateFormatter_yyyyMMdd: DateFormatter = {
+    let f = DateFormatter()
+    f.dateFormat = "yyyy-MM-dd"
+    return f
+  }()
+  private let dateFormatter_filenameTimestamp: DateFormatter = {
+    let f = DateFormatter()
+    f.dateFormat = "yyyyMMdd_HHmmssSSS"
+    return f
+  }()
+
   init() {
     // Create a persistent directory for timelapses within Application Support
     let appSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
@@ -81,9 +93,7 @@ actor VideoProcessingService {
     for date: Date,
     originalFileName: String
   ) -> URL {
-    let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "yyyy-MM-dd"
-    let dateString = dateFormatter.string(from: date)
+    let dateString = dateFormatter_yyyyMMdd.string(from: date)
 
     let dateSpecificDir =
       persistentTimelapsesRootURL
@@ -403,9 +413,7 @@ actor VideoProcessingService {
   }
 
   private func parseTimestampFromFilename(_ filename: String) -> Int? {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "yyyyMMdd_HHmmssSSS"
-    if let date = formatter.date(from: filename) {
+    if let date = dateFormatter_filenameTimestamp.date(from: filename) {
       return Int(date.timeIntervalSince1970)
     }
     return nil


### PR DESCRIPTION
## Summary

Addresses user reports of unusually high CPU usage by fixing two inefficiencies in the recording pipeline:

**Primary fix — `ScreenRecorder.jpegData`:** Replaced the `NSImage → tiffRepresentation → NSBitmapImageRep → JPEG` conversion pipeline with direct `CGImageDestination` encoding via ImageIO. The old path allocated ~8 MB of intermediate uncompressed TIFF data on every screenshot capture (every 10 seconds at 1080p), parsed it back into a bitmap rep, then re-encoded to JPEG. The new path encodes directly from `CGImage` to JPEG in a single pass.

**Secondary fix — `VideoProcessingService`:** Cached two `DateFormatter` instances (`yyyy-MM-dd` and `yyyyMMdd_HHmmssSSS`) that were being allocated on every call to `generatePersistentTimelapseURL` and `parseTimestampFromFilename`. These are now instance properties on the actor.

## Review & Testing Checklist for Human

- [ ] **Verify JPEG output quality is unchanged.** The old code used `NSBitmapImageRep` `.compressionFactor`; the new code uses `kCGImageDestinationLossyCompressionQuality`. Both accept the same `CGFloat` quality parameter, but the underlying encoders may produce subtly different output (color profiles, EXIF metadata). Run the app and compare a few saved screenshots visually and by file size.
- [ ] **Profile CPU before/after.** Use Instruments (Time Profiler) or Activity Monitor to confirm the JPEG encoding path is no longer a hotspot during steady-state recording.
- [ ] **Confirm ImageIO framework links correctly.** The `import ImageIO` addition should resolve without issues on macOS, but verify the Xcode build succeeds on your local machine.

### Notes
- The `VideoProcessingService` DateFormatter caching is lower impact since those methods aren't in the hot capture loop, but it follows existing codebase patterns (e.g. `StorageManager.DateFormatter.yyyyMMdd` and `TimeParsing.cachedHMMAFormatters`).
- `VideoProcessingService` is an `actor`, so the cached `DateFormatter` instances are protected by actor isolation — no thread-safety concern.

Link to Devin session: https://app.devin.ai/sessions/350f8da4a2ec45f1ae06dda37a01d885
Requested by: @JerryZLiu
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jerryzliu/dayflow/pull/235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
