### PR TITLE
Fix App Hanging issues (5000ms+) identified from Sentry

### DIFF
--- a/Dayflow/Dayflow/App/AppDelegate.swift
+++ b/Dayflow/Dayflow/App/AppDelegate.swift
@@ -222,22 +222,29 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
   // Start Gemini analysis as a background task
   private func setupGeminiAnalysis() {
-    // Perform after a short delay to ensure other initialization completes
-    DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+    // Initialize singletons off the main thread to avoid blocking the UI.
+    // AnalysisManager.shared triggers StorageManager.shared init which runs
+    // a database integrity check (PRAGMA quick_check) – a heavy I/O operation
+    // that was causing 5+ second hangs on main (Sentry APPLE-MACOS-B8, APPLE-MACOS-A7).
+    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 2.0) {
+      // Accessing .shared here forces lazy singleton init on this background queue
+      // instead of the main thread, avoiding the app hang.
       AnalysisManager.shared.startAnalysisJob()
-      print("AppDelegate: Gemini analysis job started")
-      AnalyticsService.shared.capture(
-        "analysis_job_started",
-        [
-          "provider": {
-            switch LLMProviderType.load() {
-            case .geminiDirect: return "gemini"
-            case .dayflowBackend: return "dayflow"
-            case .ollamaLocal: return "ollama"
-            case .chatGPTClaude: return "chat_cli"
-            }
-          }()
-        ])
+      DispatchQueue.main.async {
+        print("AppDelegate: Gemini analysis job started")
+        AnalyticsService.shared.capture(
+          "analysis_job_started",
+          [
+            "provider": {
+              switch LLMProviderType.load() {
+              case .geminiDirect: return "gemini"
+              case .dayflowBackend: return "dayflow"
+              case .ollamaLocal: return "ollama"
+              case .chatGPTClaude: return "chat_cli"
+              }
+            }()
+          ])
+      }
     }
   }
 

--- a/Dayflow/Dayflow/Core/Recording/ActiveDisplayTracker.swift
+++ b/Dayflow/Dayflow/Core/Recording/ActiveDisplayTracker.swift
@@ -21,6 +21,11 @@ final class ActiveDisplayTracker: ObservableObject {
   private let stateQueue = DispatchQueue(label: "com.dayflow.ActiveDisplayTracker.state")
   nonisolated(unsafe) private var candidateID: CGDirectDisplayID?
   nonisolated(unsafe) private var candidateSince: Date?
+  // Cache of the last committed display ID so the background poll can skip
+  // redundant @Published updates. Accessing @Published from a Task{@MainActor}
+  // triggered expensive Swift runtime conformance checks (swift_dynamicCast /
+  // swift_conformsToProtocol) causing 5s+ hangs (Sentry APPLE-MACOS-MN).
+  nonisolated(unsafe) private var lastCommittedID: CGDirectDisplayID?
 
   // Tunables
   private let pollHz: Double
@@ -116,11 +121,12 @@ final class ActiveDisplayTracker: ObservableObject {
     // Candidate is stable long enough - update the published property on main actor
     if let since = candidateSince, now.timeIntervalSince(since) >= debounceSeconds {
       let stableID = id
+      // Fast path: skip the MainActor hop entirely when the display hasn't changed.
+      guard stableID != lastCommittedID else { return }
+      lastCommittedID = stableID
       Task { @MainActor [weak self] in
         guard let self = self else { return }
-        if self.activeDisplayID != stableID {
-          self.activeDisplayID = stableID
-        }
+        self.activeDisplayID = stableID
       }
     }
   }

--- a/Dayflow/Dayflow/Core/Recording/StorageManager.swift
+++ b/Dayflow/Dayflow/Core/Recording/StorageManager.swift
@@ -687,8 +687,12 @@ final class StorageManager: StorageManaging, @unchecked Sendable {
       }
     #endif
 
-    // Run integrity check on launch (logs warning if issues found)
-    performIntegrityCheck()
+    // Run integrity check on a background queue to avoid blocking app launch.
+    // PRAGMA quick_check reads every database page – on large databases this
+    // caused 5+ second hangs on the main thread (Sentry APPLE-MACOS-B8).
+    DispatchQueue.global(qos: .utility).async { [weak self] in
+      self?.performIntegrityCheck()
+    }
 
     migrate()
     migrateLegacyChunkPathsIfNeeded()

--- a/Dayflow/Dayflow/Views/UI/CanvasTimelineDataView.swift
+++ b/Dayflow/Dayflow/Views/UI/CanvasTimelineDataView.swift
@@ -85,6 +85,9 @@ struct CanvasTimelineDataView: View {
   @State private var loadTask: Task<Void, Never>?
   // Staggered entrance animation state (Emil Kowalski principle: sequential reveal)
   @State private var cardEntranceProgress: [String: Bool] = [:]
+  // Read once at the parent level so every CanvasActivityCard gets a plain
+  // Bool instead of its own @AppStorage (avoids per-card UserDefaults I/O).
+  @AppStorage("showTimelineAppIcons") private var showTimelineAppIcons: Bool = true
   @EnvironmentObject private var categoryStore: CategoryStore
   @EnvironmentObject private var appState: AppState
   @EnvironmentObject private var retryCoordinator: RetryCoordinator
@@ -279,6 +282,7 @@ struct CanvasTimelineDataView: View {
         ForEach(Array(positionedActivities.enumerated()), id: \.element.id) { index, item in
           let isVisible = cardEntranceProgress[item.id] ?? false
           CanvasActivityCard(
+            showTimelineAppIcons: showTimelineAppIcons,
             title: item.title,
             time: item.timeLabel,
             height: item.height,
@@ -1049,7 +1053,12 @@ struct CanvasActivityCardStyle {
 }
 
 struct CanvasActivityCard: View {
-  @AppStorage("showTimelineAppIcons") private var showTimelineAppIcons: Bool = true
+  // Hoisted from @AppStorage to a plain parameter to avoid per-card
+  // UserDefaults lookups during every SwiftUI body evaluation.
+  // Each @AppStorage instance caused CFPreferences reads + memory
+  // allocation on init, triggering 5s+ hangs with many cards
+  // (Sentry APPLE-MACOS-DY, APPLE-MACOS-TN).
+  let showTimelineAppIcons: Bool
 
   let title: String
   let time: String

--- a/Dayflow/Dayflow/Views/UI/Settings/OtherSettingsViewModel.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/OtherSettingsViewModel.swift
@@ -167,6 +167,10 @@ final class OtherSettingsViewModel: ObservableObject {
       })
   }
 
+  // Use begin(completionHandler:) instead of runModal() so the save panel
+  // doesn't block the main run loop. runModal() was triggering "App hanging
+  // for at least 5000 ms" reports whenever the user took more than 5 seconds
+  // to pick a save location (Sentry APPLE-MACOS-QM).
   @MainActor
   private func presentSavePanelAndWrite(
     exportText: String,
@@ -186,35 +190,39 @@ final class OtherSettingsViewModel: ObservableObject {
     savePanel.allowedContentTypes = [.text, .plainText]
     savePanel.canCreateDirectories = true
 
-    let response = savePanel.runModal()
+    savePanel.begin { [weak self] response in
+      // The completion handler is called on the main thread.
+      Task { @MainActor in
+        guard let self else { return }
+        defer { self.isExportingTimelineRange = false }
 
-    defer { isExportingTimelineRange = false }
+        guard response == .OK, let url = savePanel.url else {
+          self.exportStatusMessage = nil
+          self.exportErrorMessage = "Export canceled"
+          return
+        }
 
-    guard response == .OK, let url = savePanel.url else {
-      exportStatusMessage = nil
-      exportErrorMessage = "Export canceled"
-      return
-    }
+        do {
+          try exportText.write(to: url, atomically: true, encoding: .utf8)
+          self.exportErrorMessage = nil
+          self.exportStatusMessage =
+            "Saved \(activityCount) activit\(activityCount == 1 ? "y" : "ies") across \(dayCount) day\(dayCount == 1 ? "" : "s") to \(url.lastPathComponent)"
 
-    do {
-      try exportText.write(to: url, atomically: true, encoding: .utf8)
-      exportErrorMessage = nil
-      exportStatusMessage =
-        "Saved \(activityCount) activit\(activityCount == 1 ? "y" : "ies") across \(dayCount) day\(dayCount == 1 ? "" : "s") to \(url.lastPathComponent)"
-
-      AnalyticsService.shared.capture(
-        "timeline_exported",
-        [
-          "start_day": dayFormatter.string(from: startDate),
-          "end_day": dayFormatter.string(from: endDate),
-          "day_count": dayCount,
-          "activity_count": activityCount,
-          "format": "markdown",
-          "file_extension": url.pathExtension.lowercased(),
-        ])
-    } catch {
-      exportStatusMessage = nil
-      exportErrorMessage = "Couldn't save file: \(error.localizedDescription)"
+          AnalyticsService.shared.capture(
+            "timeline_exported",
+            [
+              "start_day": dayFormatter.string(from: startDate),
+              "end_day": dayFormatter.string(from: endDate),
+              "day_count": dayCount,
+              "activity_count": activityCount,
+              "format": "markdown",
+              "file_extension": url.pathExtension.lowercased(),
+            ])
+        } catch {
+          self.exportStatusMessage = nil
+          self.exportErrorMessage = "Couldn't save file: \(error.localizedDescription)"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Analyzed 16 unresolved "App hanging for at least 5000 ms" issues from Sentry and implemented fixes for the 5 most impactful root causes across 5 files. All changes target main-thread blocking patterns.

**Changes by root cause:**

1. **Singleton init chain blocks main thread** (`AppDelegate.swift`, `StorageManager.swift`) — `setupGeminiAnalysis` dispatched to `DispatchQueue.main`, which triggered lazy init of `AnalysisManager.shared` → `StorageManager.shared`. The `StorageManager` init runs `PRAGMA quick_check` (reads every DB page). Moved to `DispatchQueue.global(qos: .utility)` and moved the integrity check to a background dispatch as well. *(APPLE-MACOS-B8: 50 events/38 users, APPLE-MACOS-A7: 74 events/41 users)*

2. **Per-card `@AppStorage` overhead** (`CanvasTimelineDataView.swift`) — Every `CanvasActivityCard` instance had its own `@AppStorage("showTimelineAppIcons")`, causing a UserDefaults/CFPreferences read on every card init and body evaluation. Hoisted to parent `CanvasTimelineDataView` and passed as a plain `let`. *(APPLE-MACOS-DY: 51 events/23 users, APPLE-MACOS-TN: 11 events/7 users)*

3. **`NSSavePanel.runModal()` blocks main run loop** (`OtherSettingsViewModel.swift`) — Replaced with `savePanel.begin(completionHandler:)` so the save dialog doesn't block the main thread while the user picks a location. *(APPLE-MACOS-QM: 56 events/36 users)*

4. **Redundant `@Published` property access from background poll** (`ActiveDisplayTracker.swift`) — Added a `lastCommittedID` cache so the background timer can skip the `Task { @MainActor }` hop entirely when the display hasn't changed, avoiding expensive `swift_dynamicCast` / `swift_conformsToProtocol` overhead. *(APPLE-MACOS-MN: 60 events/41 users)*

## Review & Testing Checklist for Human

- [ ] **Verify `performIntegrityCheck()` running concurrently with `migrate()` is safe** — The integrity check (`PRAGMA quick_check`, a read) now dispatches async *before* `migrate()` runs. GRDB in WAL mode should handle concurrent reads fine, but confirm no edge cases during schema migration.
- [ ] **Verify `AnalysisManager.shared.startAnalysisJob()` is safe to call from a background queue** — It internally dispatches Timer setup to `DispatchQueue.main.async`, but the singleton init itself now happens off-main. Check that `StorageManager.init` (which runs `migrate()`, purge schedulers, etc.) has no hidden main-thread requirements.
- [ ] **Test the save panel export flow** — `begin(completionHandler:)` presents a modeless panel instead of a modal one. Verify the export still works correctly (pick location → file saved → status message appears). Also verify that the app remains responsive while the panel is open and that triggering a second export while the panel is open is properly guarded.
- [ ] **Smoke test timeline with many cards** — Confirm `showTimelineAppIcons` still works correctly (app icons appear/disappear when toggled in settings) now that it's passed as a parameter instead of read per-card.

### Notes
- This is a macOS-only Swift codebase — changes could not be compiled or tested locally on the dev VM. CI build will be the first compilation check.
- The highest-volume issue (APPLE-MACOS-X, 50K events, culprit `DayflowApp.$main`) is a generic SwiftUI `AG::Subgraph::update` hang that should be reduced as a side effect of fixes #1 and #2, but won't be fully eliminated since it captures all SwiftUI graph update slowness.

Link to Devin session: https://app.devin.ai/sessions/a45960cfa1064c909ae43a84d240977b
Requested by: @JerryZLiu
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jerryzliu/dayflow/pull/236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
