### PR TITLE
fix: replay intro animation on every app reopen after soft-quit

### DIFF
--- a/Dayflow/Dayflow/App/AppDelegate.swift
+++ b/Dayflow/Dayflow/App/AppDelegate.swift
@@ -15,6 +15,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   // and the app will continue running in the background.
   static var allowTermination: Bool = false
 
+  // True after a soft-quit so the intro animation replays on reopen
+  static var didSoftQuit: Bool = false
+
   // Flag set when app is opened via notification tap - skips video intro
   static var pendingNavigationToJournal: Bool = false
   static var pendingNavigationToDailyDay: String? = nil
@@ -175,6 +178,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       return .terminateNow
     }
     // Soft-quit: hide windows and remove Dock icon, but keep status item + background tasks
+    Self.didSoftQuit = true
     NSApp.hide(nil)
     NSApp.setActivationPolicy(.accessory)
     return .terminateCancel

--- a/Dayflow/Dayflow/App/DayflowApp.swift
+++ b/Dayflow/Dayflow/App/DayflowApp.swift
@@ -171,6 +171,19 @@ struct DayflowApp: App {
           .transition(.opacity)
         }
       }
+      // Replay intro animation when app is reopened after a soft-quit
+      .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+        guard AppDelegate.didSoftQuit else { return }
+        AppDelegate.didSoftQuit = false
+
+        // Skip replay if reopened via notification tap
+        guard !hasPendingNotificationNavigation else { return }
+
+        // Reset video launch state so the intro plays again
+        showVideoLaunch = true
+        contentOpacity = 0.0
+        contentScale = 0.98
+      }
       // Inline background behind the main app UI only
       .background {
         if didOnboard {


### PR DESCRIPTION
## Summary

When the user Cmd+Q's, the app soft-quits (hides but stays alive via `terminateCancel`). The `@State showVideoLaunch` in `DayflowApp` was never reset back to `true`, so reopening the app from the status bar skipped the intro video.

This adds a `didSoftQuit` flag on `AppDelegate` that is set during soft-quit. `DayflowApp` observes `NSApplication.didBecomeActiveNotification` and, when the flag is true, resets `showVideoLaunch`, `contentOpacity`, and `contentScale` to their initial values so the video plays again. The notification-tap reopen path continues to skip the video as before.

## Review & Testing Checklist for Human

- [ ] **Soft-quit → reopen flow**: Cmd+Q the app, then reopen via status bar "Open Dayflow" — verify the intro animation plays again
- [ ] **No false triggers on normal focus change**: Switch to another app and back — verify the intro does NOT replay (the `didSoftQuit` guard should prevent this, but confirm)
- [ ] **Notification tap reopen still skips video**: Trigger a notification, tap it to reopen the app — verify the intro is skipped and navigation occurs immediately
- [ ] **No visual flash during reset**: When the video state resets, `contentOpacity` goes to 0 and `showVideoLaunch` goes to `true`. Verify there's no brief frame where the main content is visible before the video covers it (these state changes happen synchronously in the same `onReceive` closure, so SwiftUI should batch them, but worth eyeballing)

### Notes
- The fix only touches the `DayflowApp` WindowGroup path. `MainWindowContent` (used by `MainWindowManager.showMainWindow()`) already gets a fresh view when a new window is created, so it doesn't need the same fix.
- Both the flag write (`applicationShouldTerminate`) and read (`onReceive`) run on the main thread, so there's no concurrency concern.
- This was not locally tested — macOS-only app on a Linux dev environment.

Link to Devin session: https://app.devin.ai/sessions/3763500272e7452d93f5f50e002d4ec8
Requested by: @JerryZLiu
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jerryzliu/dayflow/pull/238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
