### PR TITLE
fix: stop settings hang caused by blocking XPC call on main thread

### DIFF
--- a/Dayflow/Dayflow/Core/AI/GeminiDirectProvider.swift
+++ b/Dayflow/Dayflow/Core/AI/GeminiDirectProvider.swift
@@ -267,7 +267,9 @@ final class GeminiDirectProvider {
     // realDuration is available via compressionFactor if needed for debugging
 
     let finalTranscriptionPrompt = LLMPromptTemplates.screenRecordingTranscriptionPrompt(
-      durationString: durationString)
+      durationString: durationString,
+      schema: LLMSchema.screenRecordingTranscriptionSchema
+    )
 
     // UNIFIED RETRY LOOP - Handles ALL errors comprehensively
     let maxRetries = 3
@@ -544,7 +546,8 @@ final class GeminiDirectProvider {
       transcriptText: transcriptText,
       categoriesSection: categoriesSection(from: context.categories),
       promptSections: promptSections,
-      languageBlock: languageBlock
+      languageBlock: languageBlock,
+      schema: LLMSchema.activityCardsSchema,
     )
 
     // UNIFIED RETRY LOOP - Handles ALL errors comprehensively
@@ -996,26 +999,14 @@ final class GeminiDirectProvider {
     fileURI: String, mimeType: String, prompt: String, batchId: Int64?, groupId: String,
     model: GeminiModel, attempt: Int
   ) async throws -> (String, String) {
-    let transcriptionSchema: [String: Any] = [
-      "type": "ARRAY",
-      "items": [
-        "type": "OBJECT",
-        "properties": [
-          "startTimestamp": ["type": "STRING"],
-          "endTimestamp": ["type": "STRING"],
-          "description": ["type": "STRING"],
-        ],
-        "required": ["startTimestamp", "endTimestamp", "description"],
-        "propertyOrdering": ["startTimestamp", "endTimestamp", "description"],
-      ],
-    ]
-
+    let transcriptionSchemaObject = try! JSONSerialization.jsonObject(
+      with: Data(LLMSchema.screenRecordingTranscriptionSchema.utf8))
     let generationConfig: [String: Any] = [
       "temperature": 0.3,
       "maxOutputTokens": 65536,
       "mediaResolution": "MEDIA_RESOLUTION_HIGH",
       "responseMimeType": "application/json",
-      "responseSchema": transcriptionSchema,
+      "responseJsonSchema": transcriptionSchemaObject,
     ]
 
     let requestBody: [String: Any] = [
@@ -1692,9 +1683,13 @@ final class GeminiDirectProvider {
   {
     let callStart = Date()
 
+    let activityCardsSchemaObject = try? JSONSerialization.jsonObject(
+      with: Data(LLMSchema.activityCardsSchema.utf8))
     let generationConfig: [String: Any] = [
       "temperature": 0.7,
       "maxOutputTokens": maxOutputTokens,
+      "responseMimeType": "application/json",
+      "responseJsonSchema": activityCardsSchemaObject,
     ]
 
     let requestBody: [String: Any] = [

--- a/Dayflow/Dayflow/Core/AI/GeminiDirectProvider.swift
+++ b/Dayflow/Dayflow/Core/AI/GeminiDirectProvider.swift
@@ -266,38 +266,8 @@ final class GeminiDirectProvider {
 
     // realDuration is available via compressionFactor if needed for debugging
 
-    let finalTranscriptionPrompt = """
-      Screen Recording Transcription (Reconstruct Mode)
-      Watch this screen recording and create an activity log detailed enough that someone could reconstruct the session.
-      CRITICAL: This video is exactly \(durationString) long. ALL timestamps must be within 00:00 to \(durationString). No gaps.
-      Identifying the active app: On macOS, the app name is always shown in the top-left corner of the screen, right next to the Apple () menu. Check this FIRST to identify which app is being used. Do NOT guess — read the actual name from the menu bar. If you can't read it clearly, describe it generically (e.g., "code editor," "browser," "messaging app") rather than guessing a specific product name. Common code editors like Cursor, VS Code, Xcode, and Zed all look similar but have different names in the menu bar.
-      For each segment, ask yourself:
-      "What EXACTLY did they do? What SPECIFIC things can I see?"
-      Capture:
-      - Exact app/site names visible (check menu bar for app name)
-      - Exact file names, URLs, page titles
-      - Exact usernames, search queries, messages
-      - Exact numbers, stats, prices shown
-      Bad: "Checked email"
-      Good: "Gmail: Read email from boss@company.com 'RE: Budget approval' - replied 'Looks good'"
-      Bad: "Browsing Twitter"
-      Good: "Twitter/X: Scrolled feed - viewed posts by @pmarca about AI, @sama thread on GPT-5 (12 tweets)"
-      Bad: "Working on code"
-      Good: "Editing StorageManager.swift in [exact app name from menu bar] - fixed type error on line 47, changed String to String?"
-      Segments:
-      - 3-8 segments total
-      - You may use 1 segment only if the user appears idle for most of the recording
-      - Group by GOAL not app (IDE + Terminal + Browser for the same task = 1 segment)
-      - Do not create gaps; cover the full timeline
-      Return ONLY JSON in this format:
-      [
-      {
-      "startTimestamp": "MM:SS",
-      "endTimestamp": "MM:SS",
-      "description": "1-3 sentences with specific details"
-      }
-      ]
-      """
+    let finalTranscriptionPrompt = LLMPromptTemplates.screenRecordingTranscriptionPrompt(
+      durationString: durationString)
 
     // UNIFIED RETRY LOOP - Handles ALL errors comprehensively
     let maxRetries = 3
@@ -323,53 +293,28 @@ final class GeminiDirectProvider {
           attempt: attempt + 1
         )
 
-        let videoTranscripts = try parseTranscripts(response)
+        let videoTranscripts = try LLMTranscriptUtilities.decodeTranscriptChunks(from: response)
 
-        // Convert video transcripts to observations with proper Unix timestamps
-        // Timestamps from Gemini are in compressed video time, so we expand them
-        // by the compression factor to get real-world timestamps.
-        var hasValidationErrors = false
-        let observations = videoTranscripts.compactMap { chunk -> Observation? in
-          let compressedStartSeconds = parseVideoTimestamp(chunk.startTimestamp)
-          let compressedEndSeconds = parseVideoTimestamp(chunk.endTimestamp)
-
-          // Validate timestamps are within compressed video duration (with small tolerance)
-          let tolerance: TimeInterval = 10.0  // 10 seconds tolerance in compressed time
-          if Double(compressedStartSeconds) < -tolerance
-            || Double(compressedEndSeconds) > videoDuration + tolerance
-          {
-            print(
-              "❌ VALIDATION ERROR: Observation timestamps (\(chunk.startTimestamp) - \(chunk.endTimestamp)) exceed video duration \(durationString)!"
-            )
-            hasValidationErrors = true
-            return nil
-          }
-
-          // Expand timestamps by compression factor to get real-world time
-          let realStartSeconds = TimeInterval(compressedStartSeconds) * compressionFactor
-          let realEndSeconds = TimeInterval(compressedEndSeconds) * compressionFactor
-
-          let startDate = batchStartTime.addingTimeInterval(realStartSeconds)
-          let endDate = batchStartTime.addingTimeInterval(realEndSeconds)
-
-          print(
-            "📐 Timestamp expansion: \(chunk.startTimestamp)-\(chunk.endTimestamp) → \(Int(realStartSeconds))s-\(Int(realEndSeconds))s real"
-          )
-
-          return Observation(
-            id: nil,
-            batchId: 0,  // Will be set when saved
-            startTs: Int(startDate.timeIntervalSince1970),
-            endTs: Int(endDate.timeIntervalSince1970),
-            observation: chunk.description,
-            metadata: nil,
-            llmModel: usedModel,
-            createdAt: Date()
-          )
-        }
+        // Convert video transcripts to observations with proper Unix timestamps.
+        // Timestamps from Gemini are in compressed video time, so we expand them by `compressionFactor`.
+        let conversion = LLMTranscriptUtilities.observations(
+          from: videoTranscripts,
+          batchStartTime: batchStartTime,
+          observationBatchId: 0,  // Will be set when saved
+          llmModel: usedModel,
+          compressedVideoDuration: videoDuration,
+          compressionFactor: compressionFactor,
+          tolerance: 10.0,
+          debugPrintExpansion: true
+        )
+        let observations = conversion.observations
+        let hasValidationErrors = conversion.invalidTimestampCount > 0
 
         // If we had validation errors, throw to trigger retry
         if hasValidationErrors {
+          print(
+            "❌ VALIDATION ERROR: One or more transcript chunks exceeded video duration \(durationString) (invalidCount=\(conversion.invalidTimestampCount))"
+          )
           AnalyticsService.shared.captureValidationFailure(
             provider: "gemini",
             operation: "transcribe",
@@ -588,139 +533,19 @@ final class GeminiDirectProvider {
     encoder.outputFormatting = .prettyPrinted
     let existingCardsJSON = try encoder.encode(context.existingCards)
     let existingCardsString = String(data: existingCardsJSON, encoding: .utf8) ?? "[]"
-    let promptSections = GeminiPromptSections(overrides: GeminiPromptPreferences.load())
+    let promptSections = VideoPromptSections(overrides: VideoPromptPreferences.load())
 
     let languageBlock =
       LLMOutputLanguagePreferences.languageInstruction(forJSON: true)
       .map { "\n\n\($0)" } ?? ""
 
-    let basePrompt = """
-      # Timeline Card Generation
-
-      You're writing someone's personal work journal. You'll get raw activity logs — screenshots, app switches, URLs — and your job is to turn them into timeline cards that help this person remember what they actually did.
-
-      The test: when they scan their timeline tomorrow morning, each card should make them go "oh right, that."
-
-      Write as if you ARE the person jotting down notes about their day. Not an analyst writing a report. Not a manager filing a status update.
-
-      ---
-
-      ## Card Structure
-
-      Each card covers one cohesive chunk of activity, roughly 15–60 minutes.
-
-      - Minimum 10 minutes per card. If something would be shorter, fold it into the neighboring card that makes the most sense.
-      - Maximum 60 minutes. If a card runs longer, split it where the focus naturally shifts.
-      - No gaps or overlaps between cards. If there's a real gap in the source data, preserve it. Otherwise, cards should meet cleanly.
-
-      **When to start a new card:**
-      1. What's the main thing happening right now?
-      2. Does the next chunk of activity continue that same thing? → Keep extending.
-      3. Is there a brief unrelated detour (<5 min)? → Log it as a distraction, keep the card going.
-      4. Has the focus genuinely shifted for 10+ minutes? → New card.
-
-      **When to merge with a previous card:**
-      1. Is the previous card's main activity the same as what's happening now? (same PR, same feature, same codebase, same article) → Merge.
-      2. Did the person just take a 2–5 minute break (X, messages, YouTube) and come back to the same thing? → That's a distraction, not a new card. Merge.
-      3. Are two adjacent cards both "scrolling X with occasional work check-ins"? → Merge. The vibe didn't change.
-      4. Only start a new card if the CORE INTENT changed for 10+ minutes.
-
-      DEFAULT TO MERGING. Two 15-minute cards about the same work stream should almost never exist. If you're unsure whether to merge or split, merge.
-
-      ---
-
-      \(promptSections.title)
-
-      ---
-
-      \(promptSections.summary)
-
-      ---
-
-      \(promptSections.detailedSummary)
-
-      \(languageBlock)
-
-      ---
-
-      ## Category
-
-      \(categoriesSection(from: context.categories))
-
-      ---
-
-      ## Distractions
-
-      A distraction is a brief (<5 min) unrelated interruption inside a card. Checking X for 2 minutes while debugging is a distraction. Spending 15 minutes on X is not a distraction — it's either part of the card's theme or it's a new card.
-
-      Don't label related sub-tasks as distractions. Googling an error message while debugging isn't a distraction, it's part of debugging.
-
-      ---
-
-      ## App Sites
-
-      Identify the main app or website for each card.
-
-      - primary: the main app used in the card (canonical domain, lowercase, no protocol).
-      - secondary: another meaningful app used, or the enclosing app (e.g., browser). Omit if there isn't a clear one.
-
-      Be specific: docs.google.com not google.com, mail.google.com not google.com.
-
-      Common mappings:
-      - Figma → figma.com
-      - Notion → notion.so
-      - Google Docs → docs.google.com
-      - Gmail → mail.google.com
-      - VS Code → code.visualstudio.com
-      - Xcode → developer.apple.com/xcode
-      - Twitter/X → x.com
-      - Zoom → zoom.us
-      - ChatGPT → chatgpt.com
-
-      ---
-
-      ## Continuity Rules
-
-      Your output cards must cover the same total time range as the previous cards plus any new observations. Think of previous cards as a draft you're revising and extending, not locked history.
-
-      - Don't drop time segments that were previously covered.
-      - If new observations extend beyond the previous range, add cards to cover the new time.
-      - Preserve genuine gaps in the source data.
-
-      Before generating output, review the previous cards and ask:
-      - Could any two adjacent previous cards be the same activity session?
-      - Does your first new card continue the last previous card's work?
-      If yes to either, merge them in your output.
-
-      INPUTS:
-      Previous cards: \(existingCardsString)
-      New observations: \(transcriptText)
-      Return ONLY a JSON array with this EXACT structure:
-
-              [
-                {
-                  "startTime": "1:12 AM",
-                  "endTime": "1:30 AM",
-                  "category": "",
-                  "subcategory": "",
-                  "title": "",
-                  "summary": "",
-                  "detailedSummary": "",
-                  "distractions": [
-                    {
-                      "startTime": "1:15 AM",
-                      "endTime": "1:18 AM",
-                      "title": "",
-                      "summary": ""
-                    }
-                  ],
-                  "appSites": {
-                    "primary": "",
-                    "secondary": "
-                  }
-                }
-              ]
-      """
+    let basePrompt = LLMPromptTemplates.activityCardsPrompt(
+      existingCardsString: existingCardsString,
+      transcriptText: transcriptText,
+      categoriesSection: categoriesSection(from: context.categories),
+      promptSections: promptSections,
+      languageBlock: languageBlock
+    )
 
     // UNIFIED RETRY LOOP - Handles ALL errors comprehensively
     let maxRetries = 4
@@ -1476,34 +1301,6 @@ final class GeminiDirectProvider {
     }
   }
 
-  // Temporary struct for parsing Gemini response
-  private struct VideoTranscriptChunk: Codable {
-    let startTimestamp: String  // MM:SS
-    let endTimestamp: String  // MM:SS
-    let description: String
-  }
-
-  private func parseTranscripts(_ response: String) throws -> [VideoTranscriptChunk] {
-    guard let data = response.data(using: .utf8) else {
-      print(
-        "🔎 GEMINI DEBUG: parseTranscripts received non-UTF8 or empty response: \(truncate(response, max: 400))"
-      )
-      throw NSError(
-        domain: "GeminiError", code: 8,
-        userInfo: [NSLocalizedDescriptionKey: "Invalid response encoding"])
-    }
-    do {
-      let transcripts = try JSONDecoder().decode([VideoTranscriptChunk].self, from: data)
-      return transcripts
-    } catch {
-      let snippet = truncate(String(data: data, encoding: .utf8) ?? "<non-utf8>", max: 1200)
-      print(
-        "🔎 GEMINI DEBUG: parseTranscripts JSON decode failed: \(error.localizedDescription) bodySnippet=\(snippet)"
-      )
-      throw error
-    }
-  }
-
   private func geminiCardsRequest(
     prompt: String, batchId: Int64?, groupId: String, model: GeminiModel, attempt: Int
   ) async throws -> String {
@@ -1865,267 +1662,27 @@ final class GeminiDirectProvider {
 
   // (no local logging helpers needed; centralized via LLMLogger)
 
-  private struct TimeRange {
-    let start: Double  // minutes from midnight
-    let end: Double
-  }
-
   private func timeToMinutes(_ timeStr: String) -> Double {
-    // Handle both "10:30 AM" and "05:30" formats
-    if timeStr.contains("AM") || timeStr.contains("PM") {
-      // Clock format - parse as date
-      let formatter = DateFormatter()
-      formatter.dateFormat = "h:mm a"
-      formatter.locale = Locale(identifier: "en_US_POSIX")
-
-      if let date = formatter.date(from: timeStr) {
-        let calendar = Calendar.current
-        let components = calendar.dateComponents([.hour, .minute], from: date)
-        return Double((components.hour ?? 0) * 60 + (components.minute ?? 0))
-      }
-      return 0
-    } else {
-      // MM:SS format - convert to minutes
-      let seconds = parseVideoTimestamp(timeStr)
-      return Double(seconds) / 60.0
-    }
-  }
-
-  private func mergeOverlappingRanges(_ ranges: [TimeRange]) -> [TimeRange] {
-    guard !ranges.isEmpty else { return [] }
-
-    // Sort by start time
-    let sorted = ranges.sorted { $0.start < $1.start }
-    var merged: [TimeRange] = []
-
-    for range in sorted {
-      if merged.isEmpty || range.start > merged.last!.end + 1 {
-        // No overlap - add as new range
-        merged.append(range)
-      } else {
-        // Overlap or adjacent - merge with last range
-        let last = merged.removeLast()
-        merged.append(TimeRange(start: last.start, end: max(last.end, range.end)))
-      }
-    }
-
-    return merged
+    LLMTimelineCardValidation.timeToMinutes(timeStr)
   }
 
   private func validateTimeCoverage(existingCards: [ActivityCardData], newCards: [ActivityCardData])
     -> (isValid: Bool, error: String?)
   {
-    guard !existingCards.isEmpty else {
-      return (true, nil)
-    }
-
-    // Extract time ranges from input cards
-    var inputRanges: [TimeRange] = []
-    for card in existingCards {
-      let startMin = timeToMinutes(card.startTime)
-      var endMin = timeToMinutes(card.endTime)
-      if endMin < startMin {  // Handle day rollover
-        endMin += 24 * 60
-      }
-      inputRanges.append(TimeRange(start: startMin, end: endMin))
-    }
-
-    // Merge overlapping/adjacent ranges
-    let mergedInputRanges = mergeOverlappingRanges(inputRanges)
-
-    // Extract time ranges from output cards (Fix #1: Skip zero or negative duration cards)
-    var outputRanges: [TimeRange] = []
-    for card in newCards {
-      let startMin = timeToMinutes(card.startTime)
-      var endMin = timeToMinutes(card.endTime)
-      if endMin < startMin {  // Handle day rollover
-        endMin += 24 * 60
-      }
-      // Skip zero or very short duration cards (less than 0.1 minutes = 6 seconds)
-      guard endMin - startMin >= 0.1 else {
-        continue
-      }
-      outputRanges.append(TimeRange(start: startMin, end: endMin))
-    }
-
-    // Check coverage with 3-minute flexibility
-    let flexibility = 3.0  // minutes
-    var uncoveredSegments: [(start: Double, end: Double)] = []
-
-    for inputRange in mergedInputRanges {
-      // Check if this input range is covered by output ranges
-      var coveredStart = inputRange.start
-      var safetyCounter = 10000  // Fix #3: Safety cap to prevent infinite loops
-
-      while coveredStart < inputRange.end && safetyCounter > 0 {
-        safetyCounter -= 1
-        // Find an output range that covers this point
-        var foundCoverage = false
-
-        for outputRange in outputRanges {
-          // Check if this output range covers the current point (with flexibility)
-          if outputRange.start - flexibility <= coveredStart
-            && coveredStart <= outputRange.end + flexibility
-          {
-            // Move coveredStart to the end of this output range (Fix #2: Force progress)
-            let newCoveredStart = outputRange.end
-            // Ensure we make at least minimal progress (0.01 minutes = 0.6 seconds)
-            coveredStart = max(coveredStart + 0.01, newCoveredStart)
-            foundCoverage = true
-            break
-          }
-        }
-
-        if !foundCoverage {
-          // Find the next covered point
-          var nextCovered = inputRange.end
-          for outputRange in outputRanges {
-            if outputRange.start > coveredStart && outputRange.start < nextCovered {
-              nextCovered = outputRange.start
-            }
-          }
-
-          // Add uncovered segment
-          if nextCovered > coveredStart {
-            uncoveredSegments.append((start: coveredStart, end: min(nextCovered, inputRange.end)))
-            coveredStart = nextCovered
-          } else {
-            // No more coverage found, add remaining segment and break
-            uncoveredSegments.append((start: coveredStart, end: inputRange.end))
-            break
-          }
-        }
-      }
-
-      // Check if safety counter was exhausted
-      if safetyCounter == 0 {
-        return (
-          false,
-          "Time coverage validation loop exceeded safety limit - possible infinite loop detected"
-        )
-      }
-    }
-
-    // Check if uncovered segments are significant
-    if !uncoveredSegments.isEmpty {
-      var uncoveredDesc: [String] = []
-      for segment in uncoveredSegments {
-        let duration = segment.end - segment.start
-        if duration > flexibility {  // Only report significant gaps
-          let startTime = minutesToTimeString(segment.start)
-          let endTime = minutesToTimeString(segment.end)
-          uncoveredDesc.append("\(startTime)-\(endTime) (\(Int(duration)) min)")
-        }
-      }
-
-      if !uncoveredDesc.isEmpty {
-        // Build detailed error message with input/output cards
-        var errorMsg =
-          "Missing coverage for time segments: \(uncoveredDesc.joined(separator: ", "))"
-        errorMsg += "\n\n📥 INPUT CARDS:"
-        for (i, card) in existingCards.enumerated() {
-          errorMsg += "\n  \(i+1). \(card.startTime) - \(card.endTime): \(card.title)"
-        }
-        errorMsg += "\n\n📤 OUTPUT CARDS:"
-        for (i, card) in newCards.enumerated() {
-          errorMsg += "\n  \(i+1). \(card.startTime) - \(card.endTime): \(card.title)"
-        }
-
-        return (false, errorMsg)
-      }
-    }
-
-    return (true, nil)
+    LLMTimelineCardValidation.validateTimeCoverage(existingCards: existingCards, newCards: newCards)
   }
 
   private func validateTimeline(_ cards: [ActivityCardData]) -> (isValid: Bool, error: String?) {
-    for (index, card) in cards.enumerated() {
-      let startTime = card.startTime
-      let endTime = card.endTime
-
-      var durationMinutes: Double = 0
-
-      // Check if times are in clock format (contains AM/PM)
-      if startTime.contains("AM") || startTime.contains("PM") {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "h:mm a"
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-
-        if let startDate = formatter.date(from: startTime),
-          let endDate = formatter.date(from: endTime)
-        {
-
-          var adjustedEndDate = endDate
-          // Handle day rollover (e.g., 11:30 PM to 12:30 AM)
-          if endDate < startDate {
-            adjustedEndDate =
-              Calendar.current.date(byAdding: .day, value: 1, to: endDate) ?? endDate
-          }
-
-          durationMinutes = adjustedEndDate.timeIntervalSince(startDate) / 60.0
-        } else {
-          // Failed to parse clock times
-          durationMinutes = 0
-        }
-      } else {
-        // Parse MM:SS format
-        let startSeconds = parseVideoTimestamp(startTime)
-        let endSeconds = parseVideoTimestamp(endTime)
-        durationMinutes = Double(endSeconds - startSeconds) / 60.0
-      }
-
-      // Check if card is too short (except for last card)
-      if durationMinutes < 10 && index < cards.count - 1 {
-        return (
-          false,
-          "Card \(index + 1) '\(card.title)' is only \(String(format: "%.1f", durationMinutes)) minutes long"
-        )
-      }
-    }
-
-    return (true, nil)
+    LLMTimelineCardValidation.validateTimeline(cards)
   }
 
   private func minutesToTimeString(_ minutes: Double) -> String {
-    let hours = (Int(minutes) / 60) % 24  // Handle > 24 hours
-    let mins = Int(minutes) % 60
-    let period = hours < 12 ? "AM" : "PM"
-    var displayHour = hours % 12
-    if displayHour == 0 {
-      displayHour = 12
-    }
-    return String(format: "%d:%02d %@", displayHour, mins, period)
-  }
-
-  private func parseVideoTimestamp(_ timestamp: String) -> Int {
-    let components = timestamp.components(separatedBy: ":")
-
-    if components.count == 2 {
-      // MM:SS format
-      let minutes = Int(components[0]) ?? 0
-      let seconds = Int(components[1]) ?? 0
-      return minutes * 60 + seconds
-    } else if components.count == 3 {
-      // HH:MM:SS format
-      let hours = Int(components[0]) ?? 0
-      let minutes = Int(components[1]) ?? 0
-      let seconds = Int(components[2]) ?? 0
-      return hours * 3600 + minutes * 60 + seconds
-    } else {
-      // Invalid format, return 0
-      print("Warning: Invalid video timestamp format: \(timestamp)")
-      return 0
-    }
+    LLMTimelineCardValidation.minutesToTimeString(minutes)
   }
 
   // Helper function to format timestamps
   private func formatTimestampForPrompt(_ unixTime: Int) -> String {
-    let date = Date(timeIntervalSince1970: TimeInterval(unixTime))
-    let formatter = DateFormatter()
-    formatter.dateFormat = "h:mm a"
-    formatter.locale = Locale(identifier: "en_US_POSIX")
-    formatter.timeZone = TimeZone.current
-    return formatter.string(from: date)
+    LLMTimelineCardValidation.formatTimestampForPrompt(unixTime)
   }
 
   // MARK: - Text Generation

--- a/Dayflow/Dayflow/Core/AI/GeminiPromptPreferences.swift
+++ b/Dayflow/Dayflow/Core/AI/GeminiPromptPreferences.swift
@@ -169,7 +169,7 @@ struct VideoPromptSections {
 ///
 /// When prompts must remain *exactly* identical between providers, keep them here and call these helpers.
 enum LLMPromptTemplates {
-  static func screenRecordingTranscriptionPrompt(durationString: String) -> String {
+  static func screenRecordingTranscriptionPrompt(durationString: String, schema: String) -> String {
     """
     Screen Recording Transcription (Reconstruct Mode)
     Watch this screen recording and create an activity log detailed enough that someone could reconstruct the session.
@@ -193,14 +193,8 @@ enum LLMPromptTemplates {
     - You may use 1 segment only if the user appears idle for most of the recording
     - Group by GOAL not app (IDE + Terminal + Browser for the same task = 1 segment)
     - Do not create gaps; cover the full timeline
-    Return ONLY JSON in this format:
-    [
-    {
-    "startTimestamp": "MM:SS",
-    "endTimestamp": "MM:SS",
-    "description": "1-3 sentences with specific details"
-    }
-    ]
+
+    Return a JSON array that follows the schema: \(schema)
     """
   }
 
@@ -209,7 +203,8 @@ enum LLMPromptTemplates {
     transcriptText: String,
     categoriesSection: String,
     promptSections: VideoPromptSections,
-    languageBlock: String
+    languageBlock: String,
+    schema: String,
   ) -> String {
     """
     # Timeline Card Generation
@@ -314,31 +309,8 @@ enum LLMPromptTemplates {
     INPUTS:
     Previous cards: \(existingCardsString)
     New observations: \(transcriptText)
-    Return ONLY a JSON array with this EXACT structure:
 
-            [
-              {
-                "startTime": "1:12 AM",
-                "endTime": "1:30 AM",
-                "category": "",
-                "subcategory": "",
-                "title": "",
-                "summary": "",
-                "detailedSummary": "",
-                "distractions": [
-                  {
-                    "startTime": "1:15 AM",
-                    "endTime": "1:18 AM",
-                    "title": "",
-                    "summary": ""
-                  }
-                ],
-                "appSites": {
-                  "primary": "",
-                  "secondary": ""
-                }
-              }
-            ]
+    Return a JSON array of activity cards that follows the schema: \(schema)
     """
   }
 }

--- a/Dayflow/Dayflow/Core/AI/GeminiPromptPreferences.swift
+++ b/Dayflow/Dayflow/Core/AI/GeminiPromptPreferences.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct GeminiPromptOverrides: Codable, Equatable {
+struct VideoPromptOverrides: Codable, Equatable {
   var titleBlock: String?
   var summaryBlock: String?
   var detailedBlock: String?
@@ -14,21 +14,21 @@ struct GeminiPromptOverrides: Codable, Equatable {
   }
 }
 
-enum GeminiPromptPreferences {
+enum VideoPromptPreferences {
   private static let overridesKey = "geminiPromptOverrides"
   private static let store = UserDefaults.standard
 
-  static func load() -> GeminiPromptOverrides {
+  static func load() -> VideoPromptOverrides {
     guard let data = store.data(forKey: overridesKey) else {
-      return GeminiPromptOverrides()
+      return VideoPromptOverrides()
     }
-    guard let overrides = try? JSONDecoder().decode(GeminiPromptOverrides.self, from: data) else {
-      return GeminiPromptOverrides()
+    guard let overrides = try? JSONDecoder().decode(VideoPromptOverrides.self, from: data) else {
+      return VideoPromptOverrides()
     }
     return overrides
   }
 
-  static func save(_ overrides: GeminiPromptOverrides) {
+  static func save(_ overrides: VideoPromptOverrides) {
     guard let data = try? JSONEncoder().encode(overrides) else { return }
     store.set(data, forKey: overridesKey)
   }
@@ -145,22 +145,200 @@ enum GeminiPromptDefaults {
     """
 }
 
-struct GeminiPromptSections {
+struct VideoPromptSections {
   let title: String
   let summary: String
   let detailedSummary: String
 
-  init(overrides: GeminiPromptOverrides) {
-    self.title = GeminiPromptSections.compose(
+  init(overrides: VideoPromptOverrides) {
+    self.title = VideoPromptSections.compose(
       defaultBlock: GeminiPromptDefaults.titleBlock, custom: overrides.titleBlock)
-    self.summary = GeminiPromptSections.compose(
+    self.summary = VideoPromptSections.compose(
       defaultBlock: GeminiPromptDefaults.summaryBlock, custom: overrides.summaryBlock)
-    self.detailedSummary = GeminiPromptSections.compose(
+    self.detailedSummary = VideoPromptSections.compose(
       defaultBlock: GeminiPromptDefaults.detailedSummaryBlock, custom: overrides.detailedBlock)
   }
 
   private static func compose(defaultBlock: String, custom: String?) -> String {
     let trimmed = custom?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
     return trimmed.isEmpty ? defaultBlock : trimmed
+  }
+}
+
+/// Shared prompt templates used by multiple LLM providers.
+///
+/// When prompts must remain *exactly* identical between providers, keep them here and call these helpers.
+enum LLMPromptTemplates {
+  static func screenRecordingTranscriptionPrompt(durationString: String) -> String {
+    """
+    Screen Recording Transcription (Reconstruct Mode)
+    Watch this screen recording and create an activity log detailed enough that someone could reconstruct the session.
+    CRITICAL: This video is exactly \(durationString) long. ALL timestamps must be within 00:00 to \(durationString). No gaps.
+    Identifying the active app: On macOS, the app name is always shown in the top-left corner of the screen, right next to the Apple () menu. Check this FIRST to identify which app is being used. Do NOT guess — read the actual name from the menu bar. If you can't read it clearly, describe it generically (e.g., "code editor," "browser," "messaging app") rather than guessing a specific product name. Common code editors like Cursor, VS Code, Xcode, and Zed all look similar but have different names in the menu bar.
+    For each segment, ask yourself:
+    "What EXACTLY did they do? What SPECIFIC things can I see?"
+    Capture:
+    - Exact app/site names visible (check menu bar for app name)
+    - Exact file names, URLs, page titles
+    - Exact usernames, search queries, messages
+    - Exact numbers, stats, prices shown
+    Bad: "Checked email"
+    Good: "Gmail: Read email from boss@company.com 'RE: Budget approval' - replied 'Looks good'"
+    Bad: "Browsing Twitter"
+    Good: "Twitter/X: Scrolled feed - viewed posts by @pmarca about AI, @sama thread on GPT-5 (12 tweets)"
+    Bad: "Working on code"
+    Good: "Editing StorageManager.swift in [exact app name from menu bar] - fixed type error on line 47, changed String to String?"
+    Segments:
+    - 3-8 segments total
+    - You may use 1 segment only if the user appears idle for most of the recording
+    - Group by GOAL not app (IDE + Terminal + Browser for the same task = 1 segment)
+    - Do not create gaps; cover the full timeline
+    Return ONLY JSON in this format:
+    [
+    {
+    "startTimestamp": "MM:SS",
+    "endTimestamp": "MM:SS",
+    "description": "1-3 sentences with specific details"
+    }
+    ]
+    """
+  }
+
+  static func activityCardsPrompt(
+    existingCardsString: String,
+    transcriptText: String,
+    categoriesSection: String,
+    promptSections: VideoPromptSections,
+    languageBlock: String
+  ) -> String {
+    """
+    # Timeline Card Generation
+
+    You're writing someone's personal work journal. You'll get raw activity logs — screenshots, app switches, URLs — and your job is to turn them into timeline cards that help this person remember what they actually did.
+
+    The test: when they scan their timeline tomorrow morning, each card should make them go "oh right, that."
+
+    Write as if you ARE the person jotting down notes about their day. Not an analyst writing a report. Not a manager filing a status update.
+
+    ---
+
+    ## Card Structure
+
+    Each card covers one cohesive chunk of activity, roughly 15–60 minutes.
+
+    - Minimum 10 minutes per card. If something would be shorter, fold it into the neighboring card that makes the most sense.
+    - Maximum 60 minutes. If a card runs longer, split it where the focus naturally shifts.
+    - No gaps or overlaps between cards. If there's a real gap in the source data, preserve it. Otherwise, cards should meet cleanly.
+
+    **When to start a new card:**
+    1. What's the main thing happening right now?
+    2. Does the next chunk of activity continue that same thing? → Keep extending.
+    3. Is there a brief unrelated detour (<5 min)? → Log it as a distraction, keep the card going.
+    4. Has the focus genuinely shifted for 10+ minutes? → New card.
+
+    **When to merge with a previous card:**
+      1. Is the previous card's main activity the same as what's happening now? (same PR, same feature, same codebase, same article) → Merge.
+      2. Did the person just take a 2–5 minute break (X, messages, YouTube) and come back to the same thing? → That's a distraction, not a new card. Merge.
+      3. Are two adjacent cards both "scrolling X with occasional work check-ins"? → Merge. The vibe didn't change.
+      4. Only start a new card if the CORE INTENT changed for 10+ minutes.
+
+      DEFAULT TO MERGING. Two 15-minute cards about the same work stream should almost never exist. If you're unsure whether to merge or split, merge.
+
+
+    ---
+
+    \(promptSections.title)
+
+    ---
+
+    \(promptSections.summary)
+
+    ---
+
+    \(promptSections.detailedSummary)
+
+    \(languageBlock)
+
+    ---
+
+    ## Category
+
+    \(categoriesSection)
+
+    ---
+
+    ## Distractions
+
+    A distraction is a brief (<5 min) unrelated interruption inside a card. Checking X for 2 minutes while debugging is a distraction. Spending 15 minutes on X is not a distraction — it's either part of the card's theme or it's a new card.
+
+    Don't label related sub-tasks as distractions. Googling an error message while debugging isn't a distraction, it's part of debugging.
+
+    ---
+
+    ## App Sites
+
+    Identify the main app or website for each card.
+
+    - primary: the main app used in the card (canonical domain, lowercase, no protocol).
+    - secondary: another meaningful app used, or the enclosing app (e.g., browser). Omit if there isn't a clear one.
+
+    Be specific: docs.google.com not google.com, mail.google.com not google.com.
+
+    Common mappings:
+    - Figma → figma.com
+    - Notion → notion.so
+    - Google Docs → docs.google.com
+    - Gmail → mail.google.com
+    - VS Code → code.visualstudio.com
+    - Xcode → developer.apple.com/xcode
+    - Twitter/X → x.com
+    - Zoom → zoom.us
+    - ChatGPT → chatgpt.com
+
+    ---
+
+    ## Continuity Rules
+
+    Your output cards must cover the same total time range as the previous cards plus any new observations. Think of previous cards as a draft you're revising and extending, not locked history.
+
+    - Don't drop time segments that were previously covered.
+    - If new observations extend beyond the previous range, add cards to cover the new time.
+    - Preserve genuine gaps in the source data.
+
+
+    Before generating output, review the previous cards and ask:
+    - Could any two adjacent previous cards be the same activity session?
+    - Does your first new card continue the last previous card's work?
+    If yes to either, merge them in your output.
+
+    INPUTS:
+    Previous cards: \(existingCardsString)
+    New observations: \(transcriptText)
+    Return ONLY a JSON array with this EXACT structure:
+
+            [
+              {
+                "startTime": "1:12 AM",
+                "endTime": "1:30 AM",
+                "category": "",
+                "subcategory": "",
+                "title": "",
+                "summary": "",
+                "detailedSummary": "",
+                "distractions": [
+                  {
+                    "startTime": "1:15 AM",
+                    "endTime": "1:18 AM",
+                    "title": "",
+                    "summary": ""
+                  }
+                ],
+                "appSites": {
+                  "primary": "",
+                  "secondary": ""
+                }
+              }
+            ]
+    """
   }
 }

--- a/Dayflow/Dayflow/Core/AI/LLMSchema.swift
+++ b/Dayflow/Dayflow/Core/AI/LLMSchema.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+enum LLMSchema {
+  static let screenRecordingTranscriptionSchema: String = """
+    {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "startTimestamp": {
+            "type": "string",
+            "description": "The start timestamp of the segment in 'MM:SS' format."
+          },
+          "endTimestamp": {
+            "type": "string",
+            "description": "The end timestamp of the segment in 'MM:SS' format."
+          },
+          "description": {
+            "type": "string",
+            "description": "A 1-3 sentence description of the activity in the segment."
+          }
+        },
+        "required": ["startTimestamp", "endTimestamp", "description"]
+      }
+    }
+    """
+
+  static let activityCardsSchema: String = """
+    {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "startTime": {
+            "type": "string",
+            "description": "The start time of the activity card in 'h:mm a' format (e.g., '1:12 AM')."
+          },
+          "endTime": {
+            "type": "string",
+            "description": "The end time of the activity card in 'h:mm a' format (e.g., '1:30 AM')."
+          },
+          "category": {
+            "type": "string",
+            "description": "The category of the activity."
+          },
+          "subcategory": {
+            "type": "string",
+            "description": "The subcategory of the activity."
+          },
+          "title": {
+            "type": "string",
+            "description": "A concise title for the activity card."
+          },
+          "summary": {
+            "type": "string",
+            "description": "A 2-3 sentence summary of the activity."
+          },
+          "detailedSummary": {
+            "type": "string",
+            "description": "A detailed, granular log of the activity."
+          },
+          "distractions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "startTime": {
+                  "type": "string",
+                  "description": "The start time of the distraction in 'h:mm a' format."
+                },
+                "endTime": {
+                  "type": "string",
+                  "description": "The end time of the distraction in 'h:mm a' format."
+                },
+                "title": {
+                  "type": "string",
+                  "description": "A title for the distraction."
+                },
+                "summary": {
+                  "type": "string",
+                  "description": "A summary of the distraction."
+                }
+              },
+              "required": ["startTime", "endTime", "title", "summary"]
+            }
+          },
+          "appSites": {
+            "type": "object",
+            "properties": {
+              "primary": {
+                "type": "string",
+                "description": "The primary app or website used."
+              },
+              "secondary": {
+                "type": "string",
+                "description": "The secondary app or website used."
+              }
+            },
+            "required": ["primary"]
+          }
+        },
+        "required": ["startTime", "endTime", "category", "title", "summary", "detailedSummary", "appSites"]
+      }
+    }
+    """
+}

--- a/Dayflow/Dayflow/Core/Analysis/TimeParsing.swift
+++ b/Dayflow/Dayflow/Core/Analysis/TimeParsing.swift
@@ -33,3 +33,313 @@ func parseTimeHMMA(timeString: String) -> Int? {
 
   return nil
 }
+
+// MARK: - LLM video/timeline helpers
+
+/// Shared utilities for parsing timestamps emitted by LLMs during video/timelapse transcription.
+///
+/// NOTE: These helpers are intentionally lightweight and avoid shared DateFormatter instances
+/// because DateFormatter is not thread-safe.
+enum LLMVideoTimestampUtilities {
+  /// Parses either `HH:MM:SS` or `MM:SS` into total seconds.
+  /// Returns `0` for invalid input.
+  static func parseVideoTimestamp(_ timestamp: String) -> Int {
+    let parts =
+      timestamp
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .components(separatedBy: ":")
+
+    if parts.count == 3 {
+      let h = Int(parts[0]) ?? 0
+      let m = Int(parts[1]) ?? 0
+      let s = Int(parts[2]) ?? 0
+      return h * 3600 + m * 60 + s
+    }
+    if parts.count == 2 {
+      let m = Int(parts[0]) ?? 0
+      let s = Int(parts[1]) ?? 0
+      return m * 60 + s
+    }
+    return 0
+  }
+
+  static func formatSecondsHHMMSS(_ seconds: TimeInterval) -> String {
+    let s = Int(seconds.rounded())
+    let h = s / 3600
+    let m = (s % 3600) / 60
+    let sec = s % 60
+    return String(format: "%02d:%02d:%02d", h, m, sec)
+  }
+}
+
+/// Shared validation utilities for ensuring timeline cards fully cover time ranges and
+/// don't violate minimum duration constraints.
+enum LLMTimelineCardValidation {
+  struct TimeRange {
+    let start: Double
+    let end: Double
+  }
+
+  static func formatTimestampForPrompt(_ unixTime: Int) -> String {
+    let date = Date(timeIntervalSince1970: TimeInterval(unixTime))
+    let formatter = DateFormatter()
+    formatter.dateFormat = "h:mm a"
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone.current
+    return formatter.string(from: date)
+  }
+
+  static func timeToMinutes(_ timeStr: String) -> Double {
+    let trimmed = timeStr.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let minutes = parseTimeHMMA(timeString: trimmed) {
+      return Double(minutes)
+    }
+
+    // Fallback to MM:SS / HH:MM:SS video-style time.
+    let seconds = LLMVideoTimestampUtilities.parseVideoTimestamp(trimmed)
+    return Double(seconds) / 60.0
+  }
+
+  static func minutesToTimeString(_ minutes: Double) -> String {
+    let hours = (Int(minutes) / 60) % 24
+    let mins = Int(minutes) % 60
+    let period = hours < 12 ? "AM" : "PM"
+    var displayHour = hours % 12
+    if displayHour == 0 { displayHour = 12 }
+    return String(format: "%d:%02d %@", displayHour, mins, period)
+  }
+
+  private static func mergeOverlappingRanges(_ ranges: [TimeRange]) -> [TimeRange] {
+    guard !ranges.isEmpty else { return [] }
+    let sorted = ranges.sorted { $0.start < $1.start }
+    var merged: [TimeRange] = []
+    for range in sorted {
+      if merged.isEmpty || range.start > merged.last!.end + 1 {
+        merged.append(range)
+      } else {
+        let last = merged.removeLast()
+        merged.append(TimeRange(start: last.start, end: max(last.end, range.end)))
+      }
+    }
+    return merged
+  }
+
+  static func validateTimeCoverage(existingCards: [ActivityCardData], newCards: [ActivityCardData])
+    -> (isValid: Bool, error: String?)
+  {
+    guard !existingCards.isEmpty else { return (true, nil) }
+
+    var inputRanges: [TimeRange] = []
+    for card in existingCards {
+      let startMin = timeToMinutes(card.startTime)
+      var endMin = timeToMinutes(card.endTime)
+      if endMin < startMin { endMin += 24 * 60 }
+      inputRanges.append(TimeRange(start: startMin, end: endMin))
+    }
+    let mergedInputRanges = mergeOverlappingRanges(inputRanges)
+
+    var outputRanges: [TimeRange] = []
+    for card in newCards {
+      let startMin = timeToMinutes(card.startTime)
+      var endMin = timeToMinutes(card.endTime)
+      if endMin < startMin { endMin += 24 * 60 }
+      guard endMin - startMin >= 0.1 else { continue }
+      outputRanges.append(TimeRange(start: startMin, end: endMin))
+    }
+
+    let flexibility = 3.0
+    var uncoveredSegments: [(start: Double, end: Double)] = []
+
+    for inputRange in mergedInputRanges {
+      var coveredStart = inputRange.start
+      var safetyCounter = 10000
+
+      while coveredStart < inputRange.end && safetyCounter > 0 {
+        safetyCounter -= 1
+        var foundCoverage = false
+
+        for outputRange in outputRanges {
+          if outputRange.start - flexibility <= coveredStart
+            && coveredStart <= outputRange.end + flexibility
+          {
+            let newCoveredStart = outputRange.end
+            coveredStart = max(coveredStart + 0.01, newCoveredStart)
+            foundCoverage = true
+            break
+          }
+        }
+
+        if !foundCoverage {
+          var nextCovered = inputRange.end
+          for outputRange in outputRanges {
+            if outputRange.start > coveredStart && outputRange.start < nextCovered {
+              nextCovered = outputRange.start
+            }
+          }
+          if nextCovered > coveredStart {
+            uncoveredSegments.append((start: coveredStart, end: min(nextCovered, inputRange.end)))
+            coveredStart = nextCovered
+          } else {
+            uncoveredSegments.append((start: coveredStart, end: inputRange.end))
+            break
+          }
+        }
+      }
+
+      if safetyCounter == 0 {
+        return (
+          false,
+          "Time coverage validation loop exceeded safety limit - possible infinite loop detected"
+        )
+      }
+    }
+
+    if !uncoveredSegments.isEmpty {
+      var uncoveredDesc: [String] = []
+      for segment in uncoveredSegments {
+        let duration = segment.end - segment.start
+        if duration > flexibility {
+          uncoveredDesc.append(
+            "\(minutesToTimeString(segment.start))-\(minutesToTimeString(segment.end)) (\(Int(duration)) min)"
+          )
+        }
+      }
+
+      if !uncoveredDesc.isEmpty {
+        var errorMsg =
+          "Missing coverage for time segments: \(uncoveredDesc.joined(separator: ", "))"
+        errorMsg += "\n\n📥 INPUT CARDS:"
+        for (i, card) in existingCards.enumerated() {
+          errorMsg += "\n  \(i+1). \(card.startTime) - \(card.endTime): \(card.title)"
+        }
+        errorMsg += "\n\n📤 OUTPUT CARDS:"
+        for (i, card) in newCards.enumerated() {
+          errorMsg += "\n  \(i+1). \(card.startTime) - \(card.endTime): \(card.title)"
+        }
+        return (false, errorMsg)
+      }
+    }
+
+    return (true, nil)
+  }
+
+  static func validateTimeline(_ cards: [ActivityCardData]) -> (isValid: Bool, error: String?) {
+    for (index, card) in cards.enumerated() {
+      let startTime = card.startTime
+      let endTime = card.endTime
+
+      var durationMinutes: Double = 0
+
+      if let startMin = parseTimeHMMA(timeString: startTime),
+        let endMinRaw = parseTimeHMMA(timeString: endTime)
+      {
+        var endMin = endMinRaw
+        if endMin < startMin { endMin += 24 * 60 }
+        durationMinutes = Double(endMin - startMin)
+      } else {
+        let startSeconds = LLMVideoTimestampUtilities.parseVideoTimestamp(startTime)
+        let endSeconds = LLMVideoTimestampUtilities.parseVideoTimestamp(endTime)
+        durationMinutes = Double(endSeconds - startSeconds) / 60.0
+      }
+
+      if durationMinutes < 10 && index < cards.count - 1 {
+        return (
+          false,
+          "Card \(index + 1) '\(card.title)' is only \(String(format: "%.1f", durationMinutes)) minutes long"
+        )
+      }
+    }
+    return (true, nil)
+  }
+}
+
+// MARK: - LLM transcript helpers
+
+/// Shared utilities for decoding model-generated transcript JSON and converting it into Dayflow observations.
+///
+/// Providers differ in transport, but the transcript payload is intentionally normalized to the same `[{ startTimestamp, endTimestamp, description }]` array.
+enum LLMTranscriptUtilities {
+  struct VideoTranscriptChunk: Codable {
+    let startTimestamp: String
+    let endTimestamp: String
+    let description: String
+  }
+
+  struct ObservationConversionResult {
+    let observations: [Observation]
+    /// Count of chunks dropped due to timestamp validation failures.
+    let invalidTimestampCount: Int
+  }
+
+  static func decodeTranscriptChunks(from output: String) throws -> [VideoTranscriptChunk] {
+    guard let data = output.data(using: .utf8) else {
+      throw NSError(
+        domain: "LLMTranscriptUtilities",
+        code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "Invalid response encoding"]
+      )
+    }
+    do {
+      return try JSONDecoder().decode([VideoTranscriptChunk].self, from: data)
+    } catch {
+      let snippet = String(output.prefix(400))
+      print(
+        "🔎 LLM DEBUG: decodeTranscriptChunks JSON decode failed: \(error.localizedDescription) snippet=\(snippet)"
+      )
+      throw error
+    }
+  }
+
+  static func observations(
+    from chunks: [VideoTranscriptChunk],
+    batchStartTime: Date,
+    observationBatchId: Int64,
+    llmModel: String,
+    compressedVideoDuration: TimeInterval,
+    compressionFactor: TimeInterval,
+    tolerance: TimeInterval = 10.0,
+    debugPrintExpansion: Bool = false
+  ) -> ObservationConversionResult {
+    var invalidCount = 0
+    let observations: [Observation] = chunks.compactMap { chunk in
+      let compressedStartSeconds = LLMVideoTimestampUtilities.parseVideoTimestamp(
+        chunk.startTimestamp)
+      let compressedEndSeconds = LLMVideoTimestampUtilities.parseVideoTimestamp(chunk.endTimestamp)
+
+      if Double(compressedStartSeconds) < -tolerance
+        || Double(compressedEndSeconds) > compressedVideoDuration + tolerance
+      {
+        invalidCount += 1
+        return nil
+      }
+
+      let realStartSeconds = TimeInterval(compressedStartSeconds) * compressionFactor
+      let realEndSeconds = TimeInterval(compressedEndSeconds) * compressionFactor
+
+      if debugPrintExpansion {
+        print(
+          "📐 Timestamp expansion: \(chunk.startTimestamp)-\(chunk.endTimestamp) → \(Int(realStartSeconds))s-\(Int(realEndSeconds))s real"
+        )
+      }
+
+      let startDate = batchStartTime.addingTimeInterval(realStartSeconds)
+      let endDate = batchStartTime.addingTimeInterval(realEndSeconds)
+      let trimmed = chunk.description.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty else { return nil }
+
+      return Observation(
+        id: nil,
+        batchId: observationBatchId,
+        startTs: Int(startDate.timeIntervalSince1970),
+        endTs: Int(endDate.timeIntervalSince1970),
+        observation: trimmed,
+        metadata: nil,
+        llmModel: llmModel,
+        createdAt: Date()
+      )
+    }
+
+    return ObservationConversionResult(
+      observations: observations, invalidTimestampCount: invalidCount)
+  }
+}

--- a/Dayflow/Dayflow/System/AnalyticsService.swift
+++ b/Dayflow/Dayflow/System/AnalyticsService.swift
@@ -12,6 +12,7 @@
 
 import AppKit
 import Foundation
+import OSLog
 import PostHog
 
 final class AnalyticsService {
@@ -24,6 +25,11 @@ final class AnalyticsService {
   private let backendAuthOverrideTokenKey = "dayflowBackendAuthTokenOverride"
   private let throttleLock = NSLock()
   private var throttles: [String: Date] = [:]
+
+  private let localLogger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "Dayflow",
+    category: "Analytics"
+  )
 
   var isOptedIn: Bool {
     get {
@@ -71,7 +77,7 @@ final class AnalyticsService {
       payload["$set_once"] = ["install_ts": iso8601Now()]
       UserDefaults.standard.set(true, forKey: "installTsSent")
     }
-    PostHogSDK.shared.capture("person_props_updated", properties: payload)
+    captureToPostHogAndLocal("person_props_updated", properties: payload)
   }
 
   /// Returns the stable PostHog distinct ID used as backend auth identity.
@@ -152,8 +158,14 @@ final class AnalyticsService {
 
       let payload: [String: Any] = ["$set": sanitize(["analytics_opt_in": enabled])]
       Task.detached(priority: .utility) {
-        PostHogSDK.shared.capture("person_props_updated", properties: payload)
-        PostHogSDK.shared.capture("analytics_opt_in_changed", properties: ["enabled": enabled])
+        self.captureToPostHogAndLocal(
+          "person_props_updated",
+          properties: payload
+        )
+        self.captureToPostHogAndLocal(
+          "analytics_opt_in_changed",
+          properties: ["enabled": enabled]
+        )
       }
       return
     }
@@ -186,9 +198,7 @@ final class AnalyticsService {
   func capture(_ name: String, _ props: [String: Any] = [:]) {
     guard isOptedIn else { return }
     let sanitized = sanitize(props)
-    Task.detached(priority: .utility) {
-      PostHogSDK.shared.capture(name, properties: sanitized)
-    }
+    captureToPostHogAndLocal(name, properties: sanitized)
   }
 
   func screen(_ name: String, _ props: [String: Any] = [:]) {
@@ -224,9 +234,39 @@ final class AnalyticsService {
   func setPersonProperties(_ props: [String: Any]) {
     guard isOptedIn else { return }
     let payload: [String: Any] = ["$set": sanitize(props)]
+    captureToPostHogAndLocal("person_props_updated", properties: payload)
+  }
+
+  // MARK: - Local + PostHog logging
+
+  private func captureToPostHogAndLocal(_ name: String, properties: [String: Any]) {
     Task.detached(priority: .utility) {
-      PostHogSDK.shared.capture("person_props_updated", properties: payload)
+      self.logLocal(name, properties: properties)
+      PostHogSDK.shared.capture(name, properties: properties)
     }
+  }
+
+  private func logLocal(_ event: String, properties: [String: Any]) {
+    let json = jsonString(properties)
+    let line = truncate("[Analytics] \(event) \(json)")
+    print(line)
+    localLogger.info("\(line, privacy: .public)")
+  }
+
+  private func jsonString(_ object: Any) -> String {
+    if JSONSerialization.isValidJSONObject(object),
+      let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+      let str = String(data: data, encoding: .utf8)
+    {
+      return str
+    }
+    return String(describing: object)
+  }
+
+  private func truncate(_ s: String, max: Int = 4000) -> String {
+    guard s.count > max else { return s }
+    let idx = s.index(s.startIndex, offsetBy: max)
+    return String(s[..<idx]) + "…"
   }
 
   func throttled(_ key: String, minInterval: TimeInterval, action: () -> Void) {

--- a/Dayflow/Dayflow/System/LaunchAtLoginManager.swift
+++ b/Dayflow/Dayflow/System/LaunchAtLoginManager.swift
@@ -27,20 +27,9 @@ final class LaunchAtLoginManager: ObservableObject {
   }
 
   /// Re-sync with System Settings, e.g. if the user adds/removes Dayflow manually.
-  /// This is the synchronous version for use in setEnabled() after user action.
-  func refreshStatus() {
-    let status = SMAppService.mainApp.status
-    let enabled = (status == .enabled)
-    if isEnabled != enabled {
-      logger.debug(
-        "Launch at login status changed → \(enabled ? "enabled" : "disabled") [status=\(String(describing: status))]"
-      )
-    }
-    isEnabled = enabled
-  }
-
-  /// Async version that runs the XPC call off the main actor to avoid blocking
-  private func refreshStatusAsync() async {
+  /// Callers should fire-and-forget via `Task { await refreshStatusAsync() }` or
+  /// the SwiftUI `.task {}` modifier — never call this directly from a synchronous context.
+  func refreshStatusAsync() async {
     // Run XPC call on background thread
     let status = await Task.detached(priority: .utility) {
       SMAppService.mainApp.status

--- a/Dayflow/Dayflow/System/SilentUserDriver.swift
+++ b/Dayflow/Dayflow/System/SilentUserDriver.swift
@@ -3,21 +3,25 @@ import Sparkle
 
 // A no-UI user driver that silently installs updates immediately
 final class SilentUserDriver: NSObject, SPUUserDriver {
+  var shouldAutoUpdateAndRestart: Bool = true
+
   func show(
     _ request: SPUUpdatePermissionRequest, reply: @escaping (SUUpdatePermissionResponse) -> Void
   ) {
-    print("[Sparkle] Permission request; responding with automatic checks + downloads")
+    print(
+      "[Sparkle] Permission request; responding with automatic checks + downloads (shouldAutoUpdateAndRestart=\(shouldAutoUpdateAndRestart))"
+    )
     // Enable automatic checks & downloads by default; do not send system profile
     let response = SUUpdatePermissionResponse(
-      automaticUpdateChecks: true,
-      automaticUpdateDownloading: NSNumber(value: true),
+      automaticUpdateChecks: shouldAutoUpdateAndRestart,
+      automaticUpdateDownloading: NSNumber(value: shouldAutoUpdateAndRestart),
       sendSystemProfile: false
     )
     AnalyticsService.shared.capture(
       "sparkle_permission_requested",
       [
-        "automatic_checks": true,
-        "automatic_downloads": true,
+        "automatic_checks": shouldAutoUpdateAndRestart,
+        "automatic_downloads": shouldAutoUpdateAndRestart,
       ])
     reply(response)
   }
@@ -31,8 +35,8 @@ final class SilentUserDriver: NSObject, SPUUserDriver {
     reply: @escaping (SPUUserUpdateChoice) -> Void
   ) {
     print("[Sparkle] Update found: \(appcastItem.displayVersionString)")
-    // Always proceed to install
-    reply(.install)
+    // Proceed to install only if auto-update is enabled
+    reply(shouldAutoUpdateAndRestart ? .install : .skip)
   }
 
   func showUpdateReleaseNotes(with downloadData: SPUDownloadData) {
@@ -79,11 +83,11 @@ final class SilentUserDriver: NSObject, SPUUserDriver {
   }
 
   func showReady(toInstallAndRelaunch reply: @escaping (SPUUserUpdateChoice) -> Void) {
-    print("[Sparkle] Ready to install; allowing termination")
+    print("[Sparkle] Ready to install (shouldAutoUpdateAndRestart=\(shouldAutoUpdateAndRestart))")
     Task { @MainActor in
-      AppDelegate.allowTermination = true
+      AppDelegate.allowTermination = shouldAutoUpdateAndRestart
       AnalyticsService.shared.capture("sparkle_install_ready")
-      reply(.install)
+      reply(shouldAutoUpdateAndRestart ? .install : .skip)
     }
   }
 

--- a/Dayflow/Dayflow/System/UpdaterManager.swift
+++ b/Dayflow/Dayflow/System/UpdaterManager.swift
@@ -13,7 +13,7 @@ import Sparkle
 final class UpdaterManager: NSObject, ObservableObject {
   static let shared = UpdaterManager()
 
-  private let userDriver = SilentUserDriver()
+  let userDriver = SilentUserDriver()
   private lazy var updater: SPUUpdater = {
     SPUUpdater(
       hostBundle: .main,
@@ -40,6 +40,10 @@ final class UpdaterManager: NSObject, ObservableObject {
 
   private override init() {
     super.init()
+
+    // Initialize user driver from UserDefaults
+    let automaticUpdatesEnabled = UserDefaults.standard.object(forKey: "automaticUpdatesEnabled") as? Bool ?? true
+    userDriver.shouldAutoUpdateAndRestart = automaticUpdatesEnabled
 
     // Print what Sparkle thinks the settings are *before* starting:
     print("[Sparkle] bundleId=\(Bundle.main.bundleIdentifier ?? "nil")")
@@ -124,7 +128,7 @@ extension UpdaterManager: SPUUpdaterDelegate {
   nonisolated func updaterWillRelaunchApplication(_ updater: SPUUpdater) {
     Task { @MainActor in
       print("[Sparkle] Updater will relaunch application")
-      AppDelegate.allowTermination = true
+      AppDelegate.allowTermination = false
       self.track("sparkle_app_relaunching")
     }
   }

--- a/Dayflow/Dayflow/Views/Onboarding/OnboardingLLMSelectionView.swift
+++ b/Dayflow/Dayflow/Views/Onboarding/OnboardingLLMSelectionView.swift
@@ -35,7 +35,9 @@ struct OnboardingLLMSelectionView: View {
 
       // Card width calc (no min width, cap at 480)
       let availableWidth = windowWidth - (edgePadding * 2)
-      let rawCardWidth = (availableWidth - (cardGap * 2)) / 3
+      let cardCount = max(1, providerCards.count)
+      let totalGaps = cardGap * CGFloat(max(0, cardCount - 1))
+      let rawCardWidth = (availableWidth - totalGaps) / CGFloat(cardCount)
       let cardWidth = max(1, min(480, floor(rawCardWidth)))
 
       // Card height calc

--- a/Dayflow/Dayflow/Views/Onboarding/TestConnectionView.swift
+++ b/Dayflow/Dayflow/Views/Onboarding/TestConnectionView.swift
@@ -2,17 +2,20 @@
 //  TestConnectionView.swift
 //  Dayflow
 //
-//  Test connection button for Gemini API
+//  Test connection button for supported API providers
 //
 
+import Foundation
 import SwiftUI
 
 struct TestConnectionView: View {
+  let provider: LLMProviderID
   let onTestComplete: ((Bool) -> Void)?
 
   @State private var isTesting = false
   @State private var testResult: TestResult?
-  init(onTestComplete: ((Bool) -> Void)? = nil) {
+  init(provider: LLMProviderID = .gemini, onTestComplete: ((Bool) -> Void)? = nil) {
+    self.provider = provider
     self.onTestComplete = onTestComplete
   }
 
@@ -118,37 +121,68 @@ struct TestConnectionView: View {
   private func testConnection() {
     guard !isTesting else { return }
 
-    // Get API key from keychain
-    guard let apiKey = KeychainManager.shared.retrieve(for: "gemini") else {
-      testResult = .failure("No API key found. Please enter your API key first.")
+    let analyticsProvider = provider.analyticsName
+
+    func finishFailure(_ message: String, errorCode: String? = nil) {
+      testResult = .failure(message)
       onTestComplete?(false)
-      AnalyticsService.shared.capture(
-        "connection_test_failed", ["provider": "gemini", "error_code": "no_api_key"])
+      var props: [String: Any] = ["provider": analyticsProvider]
+      if let errorCode {
+        props["error_code"] = errorCode
+      }
+      AnalyticsService.shared.capture("connection_test_failed", props)
+    }
+
+    func finishSuccess(_ message: String) {
+      testResult = .success(message)
+      isTesting = false
+      onTestComplete?(true)
+      AnalyticsService.shared.capture("connection_test_succeeded", ["provider": analyticsProvider])
+    }
+
+    // Get API key from keychain
+    let keychainKey: String
+    switch provider {
+    case .gemini:
+      keychainKey = "gemini"
+    default:
+      finishFailure(
+        "This provider doesn't support connection tests yet.", errorCode: "unsupported_provider")
+      return
+    }
+
+    guard let apiKey = KeychainManager.shared.retrieve(for: keychainKey),
+      !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else {
+      finishFailure("No API key found. Please enter your API key first.", errorCode: "no_api_key")
       return
     }
 
     isTesting = true
     testResult = nil
-    AnalyticsService.shared.capture("connection_test_started", ["provider": "gemini"])
+    AnalyticsService.shared.capture("connection_test_started", ["provider": analyticsProvider])
 
     Task {
       do {
-        let _ = try await GeminiAPIHelper.shared.testConnection(apiKey: apiKey)
-        await MainActor.run {
-          testResult = .success("Connection successful! Your API key is working.")
-          isTesting = false
-          onTestComplete?(true)
+        switch provider {
+        case .gemini:
+          let _ = try await GeminiAPIHelper.shared.testConnection(apiKey: apiKey)
+          await MainActor.run {
+            finishSuccess("Connection successful! Your API key is working.")
+          }
+        default:
+          await MainActor.run {
+            isTesting = false
+            finishFailure(
+              "This provider doesn't support connection tests yet.",
+              errorCode: "unsupported_provider")
+          }
         }
-        AnalyticsService.shared.capture("connection_test_succeeded", ["provider": "gemini"])
       } catch {
         await MainActor.run {
-          testResult = .failure(error.localizedDescription)
           isTesting = false
-          onTestComplete?(false)
+          finishFailure(error.localizedDescription, errorCode: String((error as NSError).code))
         }
-        AnalyticsService.shared.capture(
-          "connection_test_failed",
-          ["provider": "gemini", "error_code": String((error as NSError).code)])
       }
     }
   }

--- a/Dayflow/Dayflow/Views/UI/Settings/OtherSettingsViewModel.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/OtherSettingsViewModel.swift
@@ -30,6 +30,14 @@ final class OtherSettingsViewModel: ObservableObject {
       TimelapsePreferences.saveAllTimelapsesToDisk = saveAllTimelapsesToDisk
     }
   }
+  @Published var automaticUpdatesEnabled: Bool {
+    didSet {
+      guard automaticUpdatesEnabled != oldValue else { return }
+      UserDefaults.standard.set(automaticUpdatesEnabled, forKey: "automaticUpdatesEnabled")
+      // Update UpdaterManager's user driver
+      UpdaterManager.shared.userDriver.shouldAutoUpdateAndRestart = automaticUpdatesEnabled
+    }
+  }
   @Published var outputLanguageOverride: String
   @Published var isOutputLanguageOverrideSaved: Bool = true
 
@@ -50,6 +58,7 @@ final class OtherSettingsViewModel: ObservableObject {
     showTimelineAppIcons =
       UserDefaults.standard.object(forKey: "showTimelineAppIcons") as? Bool ?? true
     saveAllTimelapsesToDisk = TimelapsePreferences.saveAllTimelapsesToDisk
+    automaticUpdatesEnabled = UserDefaults.standard.object(forKey: "automaticUpdatesEnabled") as? Bool ?? true
     outputLanguageOverride = LLMOutputLanguagePreferences.override
     exportStartDate = timelineDisplayDate(from: Date())
     exportEndDate = timelineDisplayDate(from: Date())

--- a/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
@@ -768,7 +768,7 @@ final class ProvidersSettingsViewModel: ObservableObject {
   func loadGeminiPromptOverridesIfNeeded(force: Bool = false) {
     if geminiPromptOverridesLoaded && !force { return }
     isUpdatingGeminiPromptState = true
-    let overrides = GeminiPromptPreferences.load()
+    let overrides = VideoPromptPreferences.load()
 
     let trimmedTitle = overrides.titleBlock?.trimmingCharacters(in: .whitespacesAndNewlines)
     let trimmedSummary = overrides.summaryBlock?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -792,7 +792,7 @@ final class ProvidersSettingsViewModel: ObservableObject {
   }
 
   func persistGeminiPromptOverrides() {
-    let overrides = GeminiPromptOverrides(
+    let overrides = VideoPromptOverrides(
       titleBlock: normalizedOverride(
         text: geminiTitlePromptText, enabled: useCustomGeminiTitlePrompt),
       summaryBlock: normalizedOverride(
@@ -802,9 +802,9 @@ final class ProvidersSettingsViewModel: ObservableObject {
     )
 
     if overrides.isEmpty {
-      GeminiPromptPreferences.reset()
+      VideoPromptPreferences.reset()
     } else {
-      GeminiPromptPreferences.save(overrides)
+      VideoPromptPreferences.save(overrides)
     }
   }
 
@@ -816,7 +816,7 @@ final class ProvidersSettingsViewModel: ObservableObject {
     geminiTitlePromptText = GeminiPromptDefaults.titleBlock
     geminiSummaryPromptText = GeminiPromptDefaults.summaryBlock
     geminiDetailedPromptText = GeminiPromptDefaults.detailedSummaryBlock
-    GeminiPromptPreferences.reset()
+    VideoPromptPreferences.reset()
     isUpdatingGeminiPromptState = false
     geminiPromptOverridesLoaded = true
   }

--- a/Dayflow/Dayflow/Views/UI/Settings/SettingsOtherTabView.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/SettingsOtherTabView.swift
@@ -28,6 +28,18 @@ struct SettingsOtherTabView: View {
           .font(.custom("Nunito", size: 11.5))
           .foregroundColor(.black.opacity(0.5))
 
+          Toggle(isOn: $viewModel.automaticUpdatesEnabled) {
+            Text("Automatic app updates")
+              .font(.custom("Nunito", size: 13))
+              .foregroundColor(.black.opacity(0.7))
+          }
+          .toggleStyle(.switch)
+          .pointingHandCursor()
+
+          Text("When on, Dayflow automatically checks for and installs updates in the background.")
+            .font(.custom("Nunito", size: 11.5))
+            .foregroundColor(.black.opacity(0.5))
+
           Toggle(isOn: $viewModel.analyticsEnabled) {
             Text("Share crash reports and anonymous usage data")
               .font(.custom("Nunito", size: 13))

--- a/Dayflow/Dayflow/Views/UI/Settings/SettingsProvidersTabView.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/SettingsProvidersTabView.swift
@@ -92,7 +92,7 @@ struct SettingsProvidersTabView: View {
 
           switch viewModel.currentProvider {
           case "gemini":
-            TestConnectionView(onTestComplete: { _ in })
+            TestConnectionView(provider: .gemini, onTestComplete: { _ in })
           case "ollama":
             LocalLLMTestView(
               baseURL: $viewModel.localBaseURL,

--- a/Dayflow/Dayflow/Views/UI/SettingsView.swift
+++ b/Dayflow/Dayflow/Views/UI/SettingsView.swift
@@ -102,7 +102,9 @@ struct SettingsView: View {
       otherViewModel.refreshAnalyticsState()
       storageViewModel.refreshStorageIfNeeded(isStorageTab: selectedTab == .storage)
       AnalyticsService.shared.capture("settings_opened")
-      launchAtLoginManager.refreshStatus()
+    }
+    .task {
+      await launchAtLoginManager.refreshStatusAsync()
     }
     .onChange(of: selectedTab) { _, newValue in
       if newValue == .storage {


### PR DESCRIPTION

SMAppService.mainApp.status makes a synchronous XPC call to smd that
can block for 5+ seconds. The async version was already written and used
in init/bootstrapDefaultPreference, but onAppear was calling the sync
refreshStatus() instead. Switch to refreshStatusAsync() so the XPC call
runs off the main actor.

Confirmed via `sample`: 100% of samples during the hang were blocked in
mach_msg2_trap inside SMAppService's XPC pipe.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/JerryZLiu/Dayflow/pull/252).
* #212
* __->__ #252
* #250
* #228
* #227
* #226