### PR TITLE
fix(ai): set PTY winsize to avoid Claude Code 2.x TUI panic

### DIFF
--- a/Dayflow/Dayflow/Core/AI/ChatCLIRunner.swift
+++ b/Dayflow/Dayflow/Core/AI/ChatCLIRunner.swift
@@ -297,7 +297,11 @@ struct ChatCLIProcessRunner {
   private func makePseudoTerminal() throws -> PseudoTerminal {
     var master: Int32 = 0
     var slave: Int32 = 0
-    let result = openpty(&master, &slave, nil, nil, nil)
+    // Claude Code 2.x's native TUI (alacritty_terminal) panics with
+    // "index out of bounds: len is 0" when the PTY has a 0x0 grid.
+    // Initialize with a standard 80x24 winsize so the child sees a sized terminal.
+    var winSize = winsize(ws_row: 24, ws_col: 80, ws_xpixel: 0, ws_ypixel: 0)
+    let result = openpty(&master, &slave, nil, nil, &winSize)
     guard result == 0 else {
       throw NSError(
         domain: "ChatCLI", code: -50,


### PR DESCRIPTION
## Summary

`ChatCLIRunner.makePseudoTerminal()` calls `openpty(&master, &slave, nil, nil, nil)` with a `nil` winsize, so the slave terminal is created at **0 rows × 0 columns**.

Claude Code 2.x boots its native Rust TUI (`alacritty_terminal`) even when invoked with `-p --output-format stream-json`. On a 0-column grid it panics at `crates/alacritty_terminal/src/grid/mod.rs:489`:

```
thread 'main' panicked: index out of bounds: the len is 0 but the index is 18446744073709551615
```

(classic `usize` underflow from `0 - 1`). The child never emits valid JSONL, never exits, and Dayflow hits its hardcoded 300s timeout. Users see `CLI process timed out after 300 seconds` in chat, and silent empty timeline cards during background generation — likely the root cause of #174 ("Claude CLI leaves huge gaps in the timeline").

## Fix

Pass a standard 80×24 `winsize` to `openpty()` so the spawned CLI sees a sized terminal. Two-line change.

```swift
var winSize = winsize(ws_row: 24, ws_col: 80, ws_xpixel: 0, ws_ypixel: 0)
let result = openpty(&master, &slave, nil, nil, &winSize)
```

- No behavior change for `codex` (doesn't allocate a TUI grid).
- No behavior change for Claude Code 1.x (Node TUI handled 0×0 gracefully).
- Restores streaming on Claude Code 2.x.

## Test plan

- [x] Builds (Debug, macOS arm64)
- [x] Locally verified: replaced `/Applications/Dayflow.app` with patched build, Claude CLI provider now streams responses instead of timing out
- [ ] Maintainer confirmation on Intel / other Claude Code 2.x versions