### PR TITLE
fix(weekly): fix sankey crash when real bucket key collides with overflow 'other' key

### DIFF
--- a/Dayflow/Dayflow/Core/Weekly/WeeklyDashboardBuilder.swift
+++ b/Dayflow/Dayflow/Core/Weekly/WeeklyDashboardBuilder.swift
@@ -875,8 +875,12 @@ enum WeeklyDashboardBuilder {
         categories: sortedBuckets, visibleKeys: Set(sortedBuckets.map(\.key)))
     }
 
-    let visible = Array(sortedBuckets.prefix(maxVisible - 1))
-    let otherMinutes = sortedBuckets.dropFirst(maxVisible - 1).reduce(0) { $0 + $1.minutes }
+    var visible = Array(sortedBuckets.prefix(maxVisible - 1))
+    var otherMinutes = sortedBuckets.dropFirst(maxVisible - 1).reduce(0) { $0 + $1.minutes }
+    // Coalesce any pre-existing "other" bucket so the synthesised overflow doesn't duplicate its key.
+    if let collidingIndex = visible.firstIndex(where: { $0.key == otherKey }) {
+      otherMinutes += visible.remove(at: collidingIndex).minutes
+    }
     let categories =
       visible + [
         WeeklyBucket(key: otherKey, name: "Other", colorHex: otherColorHex, minutes: otherMinutes)


### PR DESCRIPTION
## Summary

The Weekly view crashes on real data via a `Dictionary(uniqueKeysWithValues:)` trap in `WeeklySankeyModelFactory.build(...)`. Root cause: `WeeklyDashboardBuilder.visibleBuckets(…)` appends a synthesised overflow bucket with `key: otherKey` (`"other"`) without first checking whether one of the real visible buckets already has key `"other"`. When the user's data contains an "Other" category/app and the bucket count exceeds `maxVisible`, the returned list has two entries keyed `"other"`, and the downstream `Dictionary(uniqueKeysWithValues:)` traps.

Full root-cause writeup and crash report in #270.

## Fix

Coalesce a pre-existing `"other"` bucket into the synthesised overflow before appending:

```swift
var visible = Array(sortedBuckets.prefix(maxVisible - 1))
var otherMinutes = sortedBuckets.dropFirst(maxVisible - 1).reduce(0) { $0 + $1.minutes }
// Coalesce any pre-existing "other" bucket so the synthesised overflow doesn't duplicate its key.
if let collidingIndex = visible.firstIndex(where: { $0.key == otherKey }) {
  otherMinutes += visible.remove(at: collidingIndex).minutes
}
```

No semantic change when no collision exists (`firstIndex` returns nil).

## Test plan

- [x] Builds (Debug, macOS arm64)
- [x] Weekly view loads on data that previously crashed (>10 distinct apps with one keyed "other")
- [x] Weekly view unchanged on data without a key collision

Fixes #270.
