### PR TITLE
Fix chat draft persistence

### DIFF
--- a/Dayflow/Dayflow/Core/AI/ChatService.swift
+++ b/Dayflow/Dayflow/Core/AI/ChatService.swift
@@ -129,6 +129,7 @@ final class ChatService: ObservableObject {
   @Published private(set) var debugLog: [ChatDebugEntry] = []
   @Published private(set) var workStatus: ChatWorkStatus?
   @Published private(set) var currentSuggestions: [String] = []
+  @Published var draftInputText = ""
   @Published var showDebugPanel = false
 
   // MARK: - Private
@@ -180,6 +181,7 @@ final class ChatService: ObservableObject {
     messages = []
     conversationHistory = []
     recentSuggestionHistory = []
+    draftInputText = ""
     streamingText = ""
     error = nil
     workStatus = nil

--- a/Dayflow/Dayflow/Views/UI/ChatView+Content.swift
+++ b/Dayflow/Dayflow/Views/UI/ChatView+Content.swift
@@ -568,7 +568,10 @@ extension ChatView {
     VStack(spacing: 0) {
       // Text input
       AppKitComposerTextField(
-        text: $inputText,
+        text: Binding(
+          get: { inputText },
+          set: { inputText = $0 }
+        ),
         isFocused: $isInputFocused,
         focusToken: composerFocusToken,
         placeholder: "Ask about your Dayflow data...",

--- a/Dayflow/Dayflow/Views/UI/ChatView.swift
+++ b/Dayflow/Dayflow/Views/UI/ChatView.swift
@@ -23,7 +23,6 @@ let chatViewMemoryUpdatedFormatter: DateFormatter = {
 
 struct ChatView: View {
   @ObservedObject var chatService = ChatService.shared
-  @State var inputText = ""
   @State var showWorkDetails = false
   @State var isInputFocused = false
   @State var composerFocusToken = 0
@@ -53,6 +52,15 @@ struct ChatView: View {
   @State var chatFeedbackShareLogs = true
   @State var chatFeedbackMode: TimelineFeedbackMode = .form
   @Environment(\.accessibilityReduceMotion) var reduceMotion
+
+  var inputText: String {
+    get {
+      chatService.draftInputText
+    }
+    nonmutating set {
+      chatService.draftInputText = newValue
+    }
+  }
 
   var body: some View {
     ZStack {

--- a/Dayflow/DayflowTests/ChatDraftTests.swift
+++ b/Dayflow/DayflowTests/ChatDraftTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+
+@testable import Dayflow
+
+@MainActor
+final class ChatDraftTests: XCTestCase {
+  func testDraftInputPersistsOnChatServiceAcrossViewRecreation() {
+    let service = ChatService()
+
+    service.draftInputText = "Summarize yesterday's work"
+
+    XCTAssertEqual(service.draftInputText, "Summarize yesterday's work")
+  }
+
+  func testClearConversationClearsDraftInput() {
+    let service = ChatService()
+    service.draftInputText = "Unsent question"
+
+    service.clearConversation()
+
+    XCTAssertEqual(service.draftInputText, "")
+  }
+}


### PR DESCRIPTION
## Summary
- Keep the Chat composer draft in ChatService instead of local ChatView state so it survives tab/view recreation.
- Clear the draft when the chat conversation is reset.
- Add unit coverage for preserving and clearing the draft.

## Tests
- xcodebuild test -project Dayflow/Dayflow.xcodeproj -scheme Dayflow -only-testing:DayflowTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO

Fixes #268