### PR TITLE
Clean markdown from Daily standup text

### DIFF
--- a/Dayflow/Dayflow/Core/AI/DailyRecapGenerator.swift
+++ b/Dayflow/Dayflow/Core/AI/DailyRecapGenerator.swift
@@ -694,10 +694,9 @@ final class DailyRecapGenerator {
       return nil
     }
 
-    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else { return nil }
-    guard trimmed.lowercased() != "null" else { return nil }
-    return trimmed
+    guard let cleaned = DailyStandupMarkdownCleaner.clean(raw) else { return nil }
+    guard cleaned.lowercased() != "null" else { return nil }
+    return cleaned
   }
 
   private static func normalizedBulletItems(from values: [String]) -> [DailyBulletItem] {

--- a/Dayflow/Dayflow/Core/AI/DailyRecapModels.swift
+++ b/Dayflow/Dayflow/Core/AI/DailyRecapModels.swift
@@ -269,4 +269,19 @@ struct DailyStandupDraft: Codable, Equatable, Sendable {
     guard let data = try? JSONEncoder().encode(self) else { return nil }
     return String(data: data, encoding: .utf8)
   }
+
+  mutating func cleanGeneratedMarkdown() {
+    highlightsTitle = DailyStandupMarkdownCleaner.clean(highlightsTitle) ?? highlightsTitle
+    highlights = highlights.compactMap { item in
+      guard let text = DailyStandupMarkdownCleaner.clean(item.text) else { return nil }
+      return DailyBulletItem(id: item.id, text: text)
+    }
+    tasksTitle = DailyStandupMarkdownCleaner.clean(tasksTitle) ?? tasksTitle
+    tasks = tasks.compactMap { item in
+      guard let text = DailyStandupMarkdownCleaner.clean(item.text) else { return nil }
+      return DailyBulletItem(id: item.id, text: text)
+    }
+    blockersTitle = DailyStandupMarkdownCleaner.clean(blockersTitle) ?? blockersTitle
+    blockersBody = DailyStandupMarkdownCleaner.clean(blockersBody) ?? blockersBody
+  }
 }

--- a/Dayflow/Dayflow/Core/AI/DailyRecapScheduler.swift
+++ b/Dayflow/Dayflow/Core/AI/DailyRecapScheduler.swift
@@ -489,18 +489,16 @@ final class DailyRecapScheduler: @unchecked Sendable {
   private static func normalizedUniqueLines(from values: [String]) -> [String] {
     var seen: Set<String> = []
     return values.compactMap { raw in
-      let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !trimmed.isEmpty else { return nil }
-      guard seen.insert(trimmed).inserted else { return nil }
-      return trimmed
+      guard let cleaned = DailyStandupMarkdownCleaner.clean(raw) else { return nil }
+      guard seen.insert(cleaned).inserted else { return nil }
+      return cleaned
     }
   }
 
   private static func normalizedBlockersText(from values: [String]) -> String {
     values
       .compactMap { value -> String? in
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
+        DailyStandupMarkdownCleaner.clean(value)
       }
       .joined(separator: "\n")
   }

--- a/Dayflow/Dayflow/Core/AI/DailyStandupMarkdownCleaner.swift
+++ b/Dayflow/Dayflow/Core/AI/DailyStandupMarkdownCleaner.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+enum DailyStandupMarkdownCleaner {
+  static func clean(_ raw: String) -> String? {
+    let normalized =
+      raw
+      .replacingOccurrences(of: "\r\n", with: "\n")
+      .replacingOccurrences(of: "\r", with: "\n")
+
+    let lines = normalized.split(separator: "\n", omittingEmptySubsequences: false).compactMap {
+      cleanLine(String($0))
+    }
+
+    let cleaned = lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+    return cleaned.isEmpty ? nil : cleaned
+  }
+
+  private static func cleanLine(_ raw: String) -> String? {
+    var line = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !line.isEmpty else { return nil }
+
+    line = replace("^>+\\s*", in: line, with: "")
+    line = replace("^#{1,6}\\s*", in: line, with: "")
+    line = replace("^[-*+]\\s+\\[[ xX]\\]\\s*", in: line, with: "")
+    line = replace("^([-*+]|\\d+[.)])\\s+", in: line, with: "")
+    line = replace("!\\[([^\\]]*)\\]\\([^)]*\\)", in: line, with: "$1")
+    line = replace("\\[([^\\]]+)\\]\\([^)]*\\)", in: line, with: "$1")
+    line = replace("`([^`]+)`", in: line, with: "$1")
+    line = replace("\\*\\*([^*]+)\\*\\*", in: line, with: "$1")
+    line = replace("__(.+?)__", in: line, with: "$1")
+    line = replace("\\*([^*]+)\\*", in: line, with: "$1")
+    line = replace("_(.+?)_", in: line, with: "$1")
+    line = replace("~~(.+?)~~", in: line, with: "$1")
+    line = line.replacingOccurrences(of: "\\", with: "")
+    line = line.trimmingCharacters(in: .whitespacesAndNewlines)
+    line = line.trimmingCharacters(in: CharacterSet(charactersIn: "#*-_`> "))
+
+    return line.isEmpty ? nil : line
+  }
+
+  private static func replace(_ pattern: String, in text: String, with template: String) -> String {
+    guard let regex = try? NSRegularExpression(pattern: pattern) else { return text }
+    let range = NSRange(text.startIndex..<text.endIndex, in: text)
+    return regex.stringByReplacingMatches(in: text, range: range, withTemplate: template)
+  }
+}

--- a/Dayflow/Dayflow/Views/UI/DailyView+Standup.swift
+++ b/Dayflow/Dayflow/Views/UI/DailyView+Standup.swift
@@ -590,7 +590,7 @@ extension DailyView {
     else {
       return nil
     }
-    return trimmed
+    return DailyStandupMarkdownCleaner.clean(trimmed)
   }
   func refreshStandupDraftIfNeeded(
     storageDayString: String,
@@ -634,6 +634,7 @@ extension DailyView {
     if decoded.generation == nil {
       decoded.generation = .legacyDayflow
     }
+    decoded.cleanGeneratedMarkdown()
     standupDraft = decoded
   }
   func scheduleStandupDraftSave() {

--- a/Dayflow/DayflowTests/DailyStandupMarkdownCleanerTests.swift
+++ b/Dayflow/DayflowTests/DailyStandupMarkdownCleanerTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+@testable import Dayflow
+
+final class DailyStandupMarkdownCleanerTests: XCTestCase {
+  func testCleansMarkdownFromGeneratedBulletText() {
+    XCTAssertEqual(
+      DailyStandupMarkdownCleaner.clean("## **Yesterday's highlights**"),
+      "Yesterday's highlights"
+    )
+    XCTAssertEqual(
+      DailyStandupMarkdownCleaner.clean("- Fixed `ChatService` markdown rendering"),
+      "Fixed ChatService markdown rendering"
+    )
+    XCTAssertEqual(
+      DailyStandupMarkdownCleaner.clean("[Reviewed PR](https://example.com) with **Claude**"),
+      "Reviewed PR with Claude"
+    )
+  }
+
+  func testReturnsNilForEmptyMarkdownAfterCleaning() {
+    XCTAssertNil(DailyStandupMarkdownCleaner.clean("- "))
+    XCTAssertNil(DailyStandupMarkdownCleaner.clean("###"))
+  }
+}


### PR DESCRIPTION
## Summary

- add a small Daily standup markdown cleaner for AI-generated editable text
- strip common markdown markers from Daily bullets, blockers, and titles before display/storage
- apply the cleanup to local Daily generation, Dayflow backend payloads, loaded drafts, and copied standup text

## Context

This is a follow-up to #232. Chat replies now have a markdown renderer, but Daily standup fields are editable `TextField`s, so markdown syntax such as headings, bullets, bold markers, inline code, and links can still leak into the Daily tab. For editable Daily text, plain cleaned content is a better fit than rendering markdown inside the fields.

## Testing

- `xcodebuild test -project Dayflow/Dayflow.xcodeproj -scheme Dayflow -only-testing:DayflowTests/DailyStandupMarkdownCleanerTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project Dayflow/Dayflow.xcodeproj -scheme Dayflow -only-testing:DayflowTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
