### PR TITLE
Fix copy timeline markdown format

### DIFF
--- a/Dayflow/Dayflow/Utilities/TimelineClipboardFormatter.swift
+++ b/Dayflow/Dayflow/Utilities/TimelineClipboardFormatter.swift
@@ -105,6 +105,38 @@ struct TimelineClipboardFormatter {
     return ([header, ""] + entries).joined(separator: "\n\n")
   }
 
+  static func makeMarkdown(
+    for weekRange: TimelineWeekRange,
+    cards: [TimelineCard],
+    now: Date = Date()
+  ) -> String {
+    let header = "# Dayflow timeline · \(weekRange.title)"
+
+    guard !cards.isEmpty else {
+      return """
+        \(header)
+
+        _No timeline activities were recorded for this week._
+        """
+    }
+
+    let cardsByDay = Dictionary(grouping: cards, by: \.day)
+    let sections = weekRange.days.compactMap { day -> String? in
+      guard let dayCards = cardsByDay[day.dayString], !dayCards.isEmpty else { return nil }
+      return makeMarkdown(for: day.date, cards: dayCards.sorted(by: cardSort), now: now)
+    }
+
+    guard !sections.isEmpty else {
+      return """
+        \(header)
+
+        _No timeline activities were recorded for this week._
+        """
+    }
+
+    return ([header, ""] + sections).joined(separator: "\n\n")
+  }
+
   private static func formattedRange(start: String, end: String) -> String {
     let trimmedStart = start.trimmingCharacters(in: .whitespacesAndNewlines)
     let trimmedEnd = end.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Dayflow/Dayflow/Views/UI/MainView/Actions.swift
+++ b/Dayflow/Dayflow/Views/UI/MainView/Actions.swift
@@ -181,7 +181,7 @@ extension MainView {
         let timelineDate = timelineDisplayDate(from: selectedDate, now: Date())
         let day = dayString(timelineDate)
         let cards = StorageManager.shared.fetchTimelineCards(forDay: day)
-        clipboardText = TimelineClipboardFormatter.makeClipboardText(
+        clipboardText = TimelineClipboardFormatter.makeMarkdown(
           for: timelineDate,
           cards: cards
         )
@@ -197,7 +197,7 @@ extension MainView {
           from: weekRange.weekStart,
           to: weekRange.weekEnd
         )
-        clipboardText = TimelineClipboardFormatter.makeClipboardText(
+        clipboardText = TimelineClipboardFormatter.makeMarkdown(
           for: weekRange,
           cards: cards
         )

--- a/Dayflow/DayflowTests/TimelineClipboardFormatterTests.swift
+++ b/Dayflow/DayflowTests/TimelineClipboardFormatterTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+
+@testable import Dayflow
+
+final class TimelineClipboardFormatterTests: XCTestCase {
+  func testWeekMarkdownUsesExportStyleSections() {
+    let weekRange = TimelineWeekRange.containing(date("2026-01-07 12:00")!)
+    let cardDay = weekRange.days[2].dayString
+    let cards = [
+      timelineCard(day: cardDay, title: "Built export flow", category: "Work")
+    ]
+
+    let markdown = TimelineClipboardFormatter.makeMarkdown(
+      for: weekRange,
+      cards: cards,
+      now: date("2026-01-07 12:00")!
+    )
+
+    XCTAssertTrue(markdown.hasPrefix("# Dayflow timeline · "))
+    XCTAssertTrue(markdown.contains("## Dayflow timeline · "))
+    XCTAssertTrue(markdown.contains("1. **09:00 AM – 10:00 AM — Built export flow**"))
+    XCTAssertTrue(markdown.contains("   - _Work_"))
+  }
+
+  private func timelineCard(day: String, title: String, category: String) -> TimelineCard {
+    TimelineCard(
+      recordId: nil,
+      batchId: nil,
+      startTimestamp: "09:00 AM",
+      endTimestamp: "10:00 AM",
+      category: category,
+      subcategory: "",
+      title: title,
+      summary: "Copied timeline output",
+      detailedSummary: "",
+      day: day,
+      distractions: nil,
+      videoSummaryURL: nil,
+      otherVideoSummaryURLs: nil,
+      appSites: nil
+    )
+  }
+
+  private func date(_ value: String) -> Date? {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd HH:mm"
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    return formatter.date(from: value)
+  }
+}


### PR DESCRIPTION
## Summary
- make copied day timelines use the existing markdown formatter
- add week markdown output with a top-level week heading and daily markdown sections
- cover week markdown copy output with a formatter test

## Tests
- xcodebuild test -project Dayflow/Dayflow.xcodeproj -scheme Dayflow -only-testing:DayflowTests/TimelineClipboardFormatterTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO\n- xcodebuild test -project Dayflow/Dayflow.xcodeproj -scheme Dayflow -only-testing:DayflowTests -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO\n\nFixes #193