### PR TITLE
Improve Week view loading performance

### DIFF
--- a/Dayflow/Dayflow/Views/UI/Weekly/WeeklyView.swift
+++ b/Dayflow/Dayflow/Views/UI/Weekly/WeeklyView.swift
@@ -368,25 +368,29 @@ struct WeeklyView: View {
     isLoading = true
     selectedWeekRecordedMinutes = nil
 
-    let previousRange = range.shifted(byWeeks: -1)
-    let cards = StorageManager.shared.fetchTimelineCardsByTimeRange(
-      from: range.weekStart,
-      to: range.weekEnd
-    )
-    let previousCards = StorageManager.shared.fetchTimelineCardsByTimeRange(
-      from: previousRange.weekStart,
-      to: previousRange.weekEnd
-    )
-    let snapshot = WeeklyDashboardBuilder.build(
-      cards: cards,
-      previousWeekCards: previousCards,
-      categories: categories,
-      weekRange: range
-    )
+    let loadResult = await Task.detached(priority: .userInitiated) {
+      let previousRange = range.shifted(byWeeks: -1)
+      let cards = StorageManager.shared.fetchTimelineCardsByTimeRange(
+        from: range.weekStart,
+        to: range.weekEnd
+      )
+      let previousCards = StorageManager.shared.fetchTimelineCardsByTimeRange(
+        from: previousRange.weekStart,
+        to: previousRange.weekEnd
+      )
+      let snapshot = WeeklyDashboardBuilder.build(
+        cards: cards,
+        previousWeekCards: previousCards,
+        categories: categories,
+        weekRange: range
+      )
 
-    guard range == weekRange else { return }
-    dashboardSnapshot = snapshot
-    selectedWeekRecordedMinutes = snapshot.donut.totalMinutes
+      return (snapshot: snapshot, selectedWeekRecordedMinutes: snapshot.donut.totalMinutes)
+    }.value
+
+    guard !Task.isCancelled, range == weekRange else { return }
+    dashboardSnapshot = loadResult.snapshot
+    selectedWeekRecordedMinutes = loadResult.selectedWeekRecordedMinutes
     isLoading = false
   }
 }

--- a/Dayflow/DayflowTests/WeeklyDashboardBuilderTests.swift
+++ b/Dayflow/DayflowTests/WeeklyDashboardBuilderTests.swift
@@ -3,6 +3,18 @@ import XCTest
 @testable import Dayflow
 
 final class WeeklyDashboardBuilderTests: XCTestCase {
+  func testWeeklyDashboardSnapshotIsSendableForBackgroundLoading() {
+    let weekRange = WeeklyDateRange.containing(Date(timeIntervalSince1970: 1_770_000_000))
+    let snapshot = WeeklyDashboardBuilder.build(
+      cards: [],
+      previousWeekCards: [],
+      categories: [],
+      weekRange: weekRange
+    )
+
+    assertSendable(snapshot)
+  }
+
   func testSankeyCoalescesRealOtherAppWithOverflowBucket() {
     let weekRange = WeeklyDateRange.containing(Date(timeIntervalSince1970: 1_770_000_000))
     let day = DateFormatter.yyyyMMdd.string(from: weekRange.weekStart)
@@ -63,5 +75,9 @@ final class WeeklyDashboardBuilderTests: XCTestCase {
       return String(format: "%d:%02d PM", hour - 12, minute)
     }
     return String(format: "%d:%02d AM", hour, minute)
+  }
+
+  private func assertSendable<T: Sendable>(_ value: T) {
+    _ = value
   }
 }


### PR DESCRIPTION
## Summary
- move Week view timeline fetches and dashboard snapshot construction into a user-initiated background task
- keep SwiftUI state updates on the main actor after checking for stale/cancelled loads
- add coverage that the weekly dashboard snapshot can be passed through background loading paths

## Tests
- `xcodebuild build -project Dayflow/Dayflow.xcodeproj -scheme Dayflow -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project Dayflow/Dayflow.xcodeproj -scheme Dayflow -only-testing:DayflowTests/WeeklyDashboardBuilderTests -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO`

Fixes #278