### PR TITLE
feat(settings): add Remove configuration for non-primary providers

### DIFF
--- a/Dayflow/Dayflow/Core/AI/GeminiModelPreference.swift
+++ b/Dayflow/Dayflow/Core/AI/GeminiModelPreference.swift
@@ -65,4 +65,8 @@ struct GeminiModelPreference: Codable {
       defaults.set(data, forKey: Self.storageKey)
     }
   }
+
+  static func clear(from defaults: UserDefaults = .standard) {
+    defaults.removeObject(forKey: storageKey)
+  }
 }

--- a/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
@@ -24,6 +24,7 @@ final class ProvidersSettingsViewModel: ObservableObject {
   @Published var localEngine: LocalEngine {
     didSet {
       guard oldValue != localEngine else { return }
+      guard !suppressLocalSettingsPersistence else { return }
       UserDefaults.standard.set(localEngine.rawValue, forKey: "llmLocalEngine")
       LocalModelPreferences.syncPreset(for: localEngine, modelId: localModelId)
       refreshUpgradeBannerState()
@@ -32,12 +33,14 @@ final class ProvidersSettingsViewModel: ObservableObject {
   @Published var localBaseURL: String {
     didSet {
       guard oldValue != localBaseURL else { return }
+      guard !suppressLocalSettingsPersistence else { return }
       UserDefaults.standard.set(localBaseURL, forKey: "llmLocalBaseURL")
     }
   }
   @Published var localModelId: String {
     didSet {
       guard oldValue != localModelId else { return }
+      guard !suppressLocalSettingsPersistence else { return }
       UserDefaults.standard.set(localModelId, forKey: "llmLocalModelId")
       LocalModelPreferences.syncPreset(for: localEngine, modelId: localModelId)
       refreshUpgradeBannerState()
@@ -46,6 +49,7 @@ final class ProvidersSettingsViewModel: ObservableObject {
   @Published var localAPIKey: String {
     didSet {
       guard oldValue != localAPIKey else { return }
+      guard !suppressLocalSettingsPersistence else { return }
       persistLocalAPIKey(localAPIKey)
     }
   }
@@ -115,6 +119,7 @@ final class ProvidersSettingsViewModel: ObservableObject {
   private var savedGeminiModel: GeminiModel
   private var pendingSetupRole: ProviderRoutingRole?
   private var pendingSetupDisplayProviderId: String?
+  private var suppressLocalSettingsPersistence = false
 
   init() {
     let preference = GeminiModelPreference.load()
@@ -580,9 +585,8 @@ final class ProvidersSettingsViewModel: ObservableObject {
       UserDefaults.standard.removeObject(forKey: "llmLocalModelId")
       UserDefaults.standard.removeObject(forKey: "llmLocalEngine")
       UserDefaults.standard.removeObject(forKey: "llmLocalAPIKey")
-      localBaseURL = ""
-      localModelId = ""
-      localAPIKey = ""
+      LocalModelPreferences.clearPreset()
+      resetLocalProviderFieldsAfterRemoval()
     case "chatgpt_claude":
       UserDefaults.standard.removeObject(forKey: "chatgpt_claudeSetupComplete")
       UserDefaults.standard.removeObject(forKey: "chatCLIPreferredTool")
@@ -598,6 +602,17 @@ final class ProvidersSettingsViewModel: ObservableObject {
         "underlying_provider": canonical,
       ])
     objectWillChange.send()
+  }
+
+  private func resetLocalProviderFieldsAfterRemoval() {
+    suppressLocalSettingsPersistence = true
+    defer { suppressLocalSettingsPersistence = false }
+
+    localEngine = .ollama
+    localBaseURL = LocalEngine.ollama.defaultBaseURL
+    localModelId = LocalModelPreferences.defaultModelId(for: .ollama)
+    localAPIKey = ""
+    showLocalModelUpgradeBanner = false
   }
 
   var backupProviderDisplayName: String {

--- a/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
@@ -553,7 +553,7 @@ final class ProvidersSettingsViewModel: ObservableObject {
     // Dayflow Pro is a server-side entitlement, not local config.
     guard canonical != "dayflow" else { return false }
     guard isProviderConfigured(providerId) else { return false }
-    guard primaryRoutingProviderId != providerId else { return false }
+    guard canonicalProviderId(for: primaryRoutingProviderId) != canonical else { return false }
     return true
   }
 
@@ -565,7 +565,7 @@ final class ProvidersSettingsViewModel: ObservableObject {
     guard canRemoveProviderConfig(providerId) else { return }
     let canonical = canonicalProviderId(for: providerId)
 
-    if isBackupProvider(providerId) {
+    if let backupProvider, backupProvider == canonical {
       clearBackupProvider()
     }
 

--- a/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
@@ -544,6 +544,62 @@ final class ProvidersSettingsViewModel: ObservableObject {
     secondaryRoutingProviderId == providerId
   }
 
+  /// True when the user is allowed to wipe the persisted config (keychain
+  /// entries, setup flags, endpoint URLs, etc.) for this provider. We
+  /// refuse to remove the config of the active primary so the app never
+  /// ends up in a state with no working primary.
+  func canRemoveProviderConfig(_ providerId: String) -> Bool {
+    let canonical = canonicalProviderId(for: providerId)
+    // Dayflow Pro is a server-side entitlement, not local config.
+    guard canonical != "dayflow" else { return false }
+    guard isProviderConfigured(providerId) else { return false }
+    guard primaryRoutingProviderId != providerId else { return false }
+    return true
+  }
+
+  /// Wipes the persisted configuration for a provider — keychain entries,
+  /// setup-complete flags, model selections, endpoint URLs, CLI tool
+  /// preference. If the provider is currently the secondary slot, also
+  /// clears the backup assignment so we don't leave a dangling reference.
+  func removeProviderConfig(_ providerId: String) {
+    guard canRemoveProviderConfig(providerId) else { return }
+    let canonical = canonicalProviderId(for: providerId)
+
+    if isBackupProvider(providerId) {
+      clearBackupProvider()
+    }
+
+    switch canonical {
+    case "gemini":
+      KeychainManager.shared.delete(for: "gemini")
+      UserDefaults.standard.removeObject(forKey: "geminiSetupComplete")
+      GeminiModelPreference.clear()
+    case "ollama":
+      UserDefaults.standard.removeObject(forKey: "ollamaSetupComplete")
+      UserDefaults.standard.removeObject(forKey: "llmLocalBaseURL")
+      UserDefaults.standard.removeObject(forKey: "llmLocalModelId")
+      UserDefaults.standard.removeObject(forKey: "llmLocalEngine")
+      UserDefaults.standard.removeObject(forKey: "llmLocalAPIKey")
+      localBaseURL = ""
+      localModelId = ""
+      localAPIKey = ""
+    case "chatgpt_claude":
+      UserDefaults.standard.removeObject(forKey: "chatgpt_claudeSetupComplete")
+      UserDefaults.standard.removeObject(forKey: "chatCLIPreferredTool")
+      preferredCLITool = nil
+    default:
+      return
+    }
+
+    AnalyticsService.shared.capture(
+      "provider_config_removed",
+      [
+        "provider": providerId,
+        "underlying_provider": canonical,
+      ])
+    objectWillChange.send()
+  }
+
   var backupProviderDisplayName: String {
     guard let backupProvider = secondaryRoutingProviderId else { return "Not configured" }
     return providerDisplayName(backupProvider)
@@ -837,7 +893,7 @@ final class ProvidersSettingsViewModel: ObservableObject {
     }
   }
 
-  private func canonicalProviderId(for displayProviderId: String) -> String {
+  func canonicalProviderId(for displayProviderId: String) -> String {
     switch displayProviderId {
     case "chatgpt", "claude", "chatgpt_claude":
       return "chatgpt_claude"

--- a/Dayflow/Dayflow/Views/UI/Settings/SettingsProvidersTabView.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/SettingsProvidersTabView.swift
@@ -5,6 +5,9 @@ struct SettingsProvidersTabView: View {
   @ObservedObject var viewModel: ProvidersSettingsViewModel
   @ObservedObject private var authManager = DayflowAuthManager.shared
 
+  /// Provider id pending a config removal, used to drive the confirmation alert.
+  @State private var providerPendingRemoval: String?
+
   var body: some View {
     VStack(alignment: .leading, spacing: SettingsStyle.sectionSpacing) {
       if viewModel.currentProvider == "ollama", viewModel.showLocalModelUpgradeBanner {
@@ -34,6 +37,38 @@ struct SettingsProvidersTabView: View {
       }
 
       promptCustomizationSection
+    }
+    .alert(
+      "Remove configuration?",
+      isPresented: Binding(
+        get: { providerPendingRemoval != nil },
+        set: { newValue in if !newValue { providerPendingRemoval = nil } }
+      )
+    ) {
+      Button("Cancel", role: .cancel) { providerPendingRemoval = nil }
+      Button("Remove", role: .destructive) {
+        if let id = providerPendingRemoval {
+          viewModel.removeProviderConfig(id)
+        }
+        providerPendingRemoval = nil
+      }
+    } message: {
+      Text(removalConfirmationMessage(for: providerPendingRemoval))
+    }
+  }
+
+  private func removalConfirmationMessage(for providerId: String?) -> String {
+    guard let providerId else { return "" }
+    let name = viewModel.providerDisplayName(providerId)
+    switch viewModel.canonicalProviderId(for: providerId) {
+    case "gemini":
+      return "This will delete your Gemini API key from Keychain and reset \(name)'s saved settings. You'll need to re-enter the key to use this provider again."
+    case "ollama":
+      return "This will clear your saved \(name) endpoint, model selection, and local API key. You can re-run setup any time."
+    case "chatgpt_claude":
+      return "This will clear the saved CLI tool preference for \(name). You can re-run setup any time."
+    default:
+      return "This will clear all saved configuration for \(name)."
     }
   }
 
@@ -266,6 +301,12 @@ struct SettingsProvidersTabView: View {
           } else {
             SettingsSecondaryButton(title: "Unset secondary") {
               viewModel.clearBackupProvider()
+            }
+          }
+
+          if viewModel.canRemoveProviderConfig(provider.id) {
+            SettingsSecondaryButton(title: "Remove configuration") {
+              providerPendingRemoval = provider.id
             }
           }
         }


### PR DESCRIPTION
## Summary

There's currently no way to remove a configured provider from Settings → Providers — you can only switch which one is active. If you've experimented with multiple providers (Local, Gemini, ChatGPT/Claude) the abandoned configs, Keychain entries, and UserDefaults keys stay around indefinitely, and the only escape hatch is hand-editing.

This PR adds a **Remove configuration** affordance for non-primary providers, plus two safety fixes for edge cases the removal path uncovered during implementation.

## 1. Add Remove configuration UI (feat)

A "Remove configuration" button on each non-primary provider row in `SettingsProvidersTabView`, wired through a new `ProvidersSettingsViewModel.removeProviderConfig(_:)` which:

- Deletes Keychain entries for the provider
- Removes `\(provider)SetupComplete` and provider-specific UserDefaults (model id, base URL, CLI tool preference)
- Clears the backup-provider slot if this provider occupied it
- Resets in-memory `@Published` state so the UI reflects the cleared config immediately

`canRemoveProviderConfig(_:)` gates the affordance to prevent removing:
- Dayflow Pro (server-side entitlement, not local config)
- A provider that isn't configured in the first place
- The currently-active primary

## 2. Compare canonical provider IDs when gating removal (fix)

ChatGPT and Claude share one persisted config under the canonical id `chatgpt_claude`, but each surfaces as its own provider id in the routing layer. The initial guard compared raw provider IDs, which meant the `chatgpt_claude` config could be removed while `claude` (or `chatgpt`) was still active — bricking the provider until the user re-onboarded.

```swift
- guard primaryRoutingProviderId != providerId else { return false }
+ guard canonicalProviderId(for: primaryRoutingProviderId) != canonical else { return false }
```

The backup-clear branch in `removeProviderConfig` gets the same canonical comparison.

## 3. Stop UserDefaults write-back race on Local provider removal (fix)

The Local-provider branch of `removeProviderConfig` called `UserDefaults.removeObject(forKey:)` for `llmLocalBaseURL`, `llmLocalModelId`, `llmLocalEngine`, `llmLocalAPIKey`, then set the corresponding `@Published` properties to `""`. Each `@Published` has a `didSet` that writes the new value back into UserDefaults — so the removes were immediately overwritten with empty strings, leaving stale empty-string keys instead of cleared state.

Fix:
- Add a `suppressLocalSettingsPersistence` flag guarded inside every Local-prop `didSet`
- Extract `resetLocalProviderFieldsAfterRemoval()` which flips the flag, restores **proper defaults** (Ollama base URL, default model id) rather than blanks, and clears the flag in `defer`
- Also call `LocalModelPreferences.clearPreset()` so the preset selection doesn't survive removal

## Test plan

- [x] Builds (Debug, macOS arm64)
- [x] Configure two providers, switch primary, verify "Remove configuration" appears on the non-primary row only
- [x] Remove Gemini → Keychain entry deleted, `geminiSetupComplete` cleared, UI reverts to "Not configured"
- [x] Remove Local → UserDefaults keys actually removed (no empty-string ghosts), in-memory fields reset to Ollama defaults
- [x] Try to remove the active primary → button absent / disabled
- [x] With Claude as primary, "Remove configuration" hidden on `chatgpt_claude` row until primary switches away
- [x] With Local as backup, removing Local clears the backup slot, primary intact