### PR TITLE
feat: deep-link timeline export (dayflow://export-timeline)

### DIFF
--- a/Dayflow/Dayflow/AnalyticsEventDictionary.md
+++ b/Dayflow/Dayflow/AnalyticsEventDictionary.md
@@ -100,6 +100,12 @@ This document lists manual events, properties, and code locations. All events re
 - timeline_copied
   - props: `timeline_mode: day|week`, `timeline_day?: yyyy-MM-dd`, `week_start?: yyyy-MM-dd`, `week_end?: yyyy-MM-dd`, `activity_count: int`
   - file: Views/UI/MainView.swift
+- timeline_exported
+  - props: `start_day: yyyy-MM-dd`, `end_day: yyyy-MM-dd`, `day_count: int`, `activity_count: int`, `format: markdown`, `file_extension: string`, `source: ui|deeplink`
+  - files: Views/UI/Settings/OtherSettingsViewModel.swift (Settings export), App/TimelineExportService.swift (dayflow://export-timeline deep link)
+- timeline_export_failed
+  - props: `source: deeplink`, `error: destination_not_allowed|string`
+  - file: App/TimelineExportService.swift
 
 ## Dashboard Chat
 - chat_question_asked

--- a/Dayflow/Dayflow/App/AppDeepLinkRouter.swift
+++ b/Dayflow/Dayflow/App/AppDeepLinkRouter.swift
@@ -114,7 +114,9 @@ final class AppDeepLinkRouter {
   private func exportTimeline(from url: URL) {
     switch TimelineExportRequest.parse(url: url) {
     case .success(let request):
-      Task.detached(priority: .userInitiated) {
+      // Run off the main thread. Use a GCD queue rather than Task.detached so the synchronous
+      // database reads and file write don't occupy a Swift cooperative thread.
+      DispatchQueue.global(qos: .userInitiated).async {
         TimelineExportService.run(request)
       }
     case .failure(let error):

--- a/Dayflow/Dayflow/App/AppDeepLinkRouter.swift
+++ b/Dayflow/Dayflow/App/AppDeepLinkRouter.swift
@@ -6,6 +6,7 @@ final class AppDeepLinkRouter {
     case startRecording = "start-recording"
     case stopRecording = "stop-recording"
     case referral = "referral"
+    case exportTimeline = "export-timeline"
 
     init?(identifier: String) {
       switch identifier.lowercased() {
@@ -15,6 +16,8 @@ final class AppDeepLinkRouter {
         self = .stopRecording
       case Self.referral.rawValue, "claim", "r":
         self = .referral
+      case Self.exportTimeline.rawValue, "export":
+        self = .exportTimeline
       default:
         return nil
       }
@@ -71,6 +74,8 @@ final class AppDeepLinkRouter {
       stopRecording()
     case .referral:
       saveReferralCode(from: url)
+    case .exportTimeline:
+      exportTimeline(from: url)
     }
   }
 
@@ -104,6 +109,17 @@ final class AppDeepLinkRouter {
       return
     }
     DayflowAuthManager.shared.setPendingReferralCode(code)
+  }
+
+  private func exportTimeline(from url: URL) {
+    switch TimelineExportRequest.parse(url: url) {
+    case .success(let request):
+      Task.detached(priority: .userInitiated) {
+        TimelineExportService.run(request)
+      }
+    case .failure(let error):
+      print("[DeepLink] export-timeline: \(error)")
+    }
   }
 
 }

--- a/Dayflow/Dayflow/App/TimelineExportRequest.swift
+++ b/Dayflow/Dayflow/App/TimelineExportRequest.swift
@@ -19,7 +19,13 @@ struct TimelineExportRequest: Equatable {
   enum ParseError: Error, Equatable {
     case invalidDate(String)
     case startAfterEnd
+    case rangeTooLarge
   }
+
+  /// Maximum number of days an export may span (inclusive). Bounds the work a single deep link
+  /// can trigger — without it, `start=2000-01-01&end=2030-01-01` would force thousands of
+  /// database reads on a background thread.
+  static let maxRangeDays = 366
 
   /// Parses a `dayflow://export-timeline?...` URL into a validated request.
   ///
@@ -33,10 +39,16 @@ struct TimelineExportRequest: Equatable {
   static func parse(url: URL, now: Date = Date()) -> Result<TimelineExportRequest, ParseError> {
     let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
 
+    // Resolve in preference order: the first name with a non-empty value wins, regardless of
+    // where it appears in the query string (so `path` beats its `to`/`destination` aliases).
     func value(forAny names: [String]) -> String? {
-      for item in items where names.contains(item.name.lowercased()) {
-        if let trimmed = item.value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty {
-          return trimmed
+      for name in names {
+        for item in items where item.name.lowercased() == name {
+          if let trimmed = item.value?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !trimmed.isEmpty
+          {
+            return trimmed
+          }
         }
       }
       return nil
@@ -75,6 +87,9 @@ struct TimelineExportRequest: Equatable {
 
     guard startDay <= endDay else { return .failure(.startAfterEnd) }
 
+    let span = Calendar.current.dateComponents([.day], from: startDay, to: endDay).day ?? 0
+    guard span < maxRangeDays else { return .failure(.rangeTooLarge) }
+
     return .success(
       TimelineExportRequest(
         startDay: startDay,
@@ -101,6 +116,6 @@ struct TimelineExportRequest: Equatable {
 
   private static func parseBool(_ value: String?) -> Bool {
     guard let value = value?.lowercased() else { return false }
-    return ["true", "1", "yes", "y"].contains(value)
+    return ["true", "1", "yes"].contains(value)
   }
 }

--- a/Dayflow/Dayflow/App/TimelineExportRequest.swift
+++ b/Dayflow/Dayflow/App/TimelineExportRequest.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// Parsed, validated parameters for a `dayflow://export-timeline` deep link.
+///
+/// This is a pure value type: parsing performs no file or database I/O, so it can be
+/// unit tested in isolation. The side effects (fetching cards, writing the file) live in
+/// `TimelineExportService`.
+struct TimelineExportRequest: Equatable {
+  /// First timeline day to export (inclusive), normalized to the timeline-day representation (noon).
+  let startDay: Date
+  /// Last timeline day to export (inclusive).
+  let endDay: Date
+  /// Raw destination from the URL (`path`/`to`/`destination`), or `nil` for the default location.
+  /// Kept verbatim (including a leading `~`); resolved to a concrete URL by `TimelineExportService`.
+  let destinationPath: String?
+  /// Whether to reveal the exported file in Finder once written.
+  let reveal: Bool
+
+  enum ParseError: Error, Equatable {
+    case invalidDate(String)
+    case startAfterEnd
+  }
+
+  /// Parses a `dayflow://export-timeline?...` URL into a validated request.
+  ///
+  /// Recognized query items (keys matched case-insensitively):
+  /// - `date`: `today` | `yesterday` | `YYYY-MM-DD` — exports a single day.
+  /// - `start` / `end`: same token grammar — inclusive range. Presence of either selects range mode.
+  /// - `path` (aliases `to`, `destination`): output file or directory path.
+  /// - `reveal`: `true` | `1` | `yes` reveals the file in Finder afterward.
+  ///
+  /// Precedence: range mode (when `start`/`end` present) > `date` > default (today).
+  static func parse(url: URL, now: Date = Date()) -> Result<TimelineExportRequest, ParseError> {
+    let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+
+    func value(forAny names: [String]) -> String? {
+      for item in items where names.contains(item.name.lowercased()) {
+        if let trimmed = item.value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty {
+          return trimmed
+        }
+      }
+      return nil
+    }
+
+    let startToken = value(forAny: ["start"])
+    let endToken = value(forAny: ["end"])
+    let dateToken = value(forAny: ["date"])
+
+    let startDay: Date
+    let endDay: Date
+
+    if startToken != nil || endToken != nil {
+      // Range mode. A missing side falls back to the other (a single-ended range still works).
+      let resolvedStartToken = startToken ?? endToken ?? "today"
+      let resolvedEndToken = endToken ?? startToken ?? "today"
+      guard let resolvedStart = resolveDay(resolvedStartToken, now: now) else {
+        return .failure(.invalidDate(resolvedStartToken))
+      }
+      guard let resolvedEnd = resolveDay(resolvedEndToken, now: now) else {
+        return .failure(.invalidDate(resolvedEndToken))
+      }
+      startDay = resolvedStart
+      endDay = resolvedEnd
+    } else if let dateToken {
+      guard let resolved = resolveDay(dateToken, now: now) else {
+        return .failure(.invalidDate(dateToken))
+      }
+      startDay = resolved
+      endDay = resolved
+    } else {
+      let today = timelineDisplayDate(from: now, now: now)
+      startDay = today
+      endDay = today
+    }
+
+    guard startDay <= endDay else { return .failure(.startAfterEnd) }
+
+    return .success(
+      TimelineExportRequest(
+        startDay: startDay,
+        endDay: endDay,
+        destinationPath: value(forAny: ["path", "to", "destination"]),
+        reveal: parseBool(value(forAny: ["reveal"]))
+      ))
+  }
+
+  /// Resolves a date token (`today`, `yesterday`, or `YYYY-MM-DD`) to a normalized timeline day.
+  /// Returns `nil` for unrecognized or malformed tokens.
+  static func resolveDay(_ token: String, now: Date = Date()) -> Date? {
+    switch token.lowercased() {
+    case "today":
+      return timelineDisplayDate(from: now, now: now)
+    case "yesterday":
+      let today = timelineDisplayDate(from: now, now: now)
+      return Calendar.current.date(byAdding: .day, value: -1, to: today)
+    default:
+      guard let parsed = DateFormatter.yyyyMMdd.date(from: token) else { return nil }
+      return normalizedTimelineDate(parsed)
+    }
+  }
+
+  private static func parseBool(_ value: String?) -> Bool {
+    guard let value = value?.lowercased() else { return false }
+    return ["true", "1", "yes", "y"].contains(value)
+  }
+}

--- a/Dayflow/Dayflow/App/TimelineExportService.swift
+++ b/Dayflow/Dayflow/App/TimelineExportService.swift
@@ -5,12 +5,16 @@ import Foundation
 /// for the requested range, resolves the destination path, writes the file, emits analytics,
 /// and optionally reveals the result in Finder.
 ///
-/// The path/name resolution is factored into pure static helpers so it can be unit tested
-/// without touching the real filesystem.
+/// The path resolution is factored into pure static helpers so it can be unit tested without
+/// touching the real filesystem.
+///
+/// Because the `dayflow://` URL scheme is invokable by any local process or by a webpage (and
+/// the app is not sandboxed), the caller-supplied destination is treated as untrusted: writes
+/// are constrained to the user's standard export folders (Downloads, Documents, Desktop) and
+/// `..` traversal is collapsed before that check. See `resolveDestination`.
 enum TimelineExportService {
-  /// Runs the export described by `request`. Intended to be called off the main actor
-  /// (the deep-link router dispatches it on a detached task). Fails soft: errors are logged
-  /// and reported to analytics, never thrown.
+  /// Runs the export described by `request`. Intended to be called off the main actor.
+  /// Fails soft: errors are logged and reported to analytics, never thrown.
   static func run(_ request: TimelineExportRequest, now: Date = Date()) {
     let output = TimelineRangeExport.build(
       startDay: request.startDay,
@@ -18,11 +22,21 @@ enum TimelineExportService {
       now: now
     )
 
-    let destination = resolveDestination(
-      rawPath: request.destinationPath,
-      startDay: request.startDay,
-      endDay: request.endDay
-    )
+    guard
+      let destination = resolveDestination(
+        rawPath: request.destinationPath,
+        startDay: request.startDay,
+        endDay: request.endDay
+      )
+    else {
+      print(
+        "[DeepLink] export-timeline: refused destination "
+          + "\(request.destinationPath ?? "<default>") — outside the allowed export folders "
+          + "(Downloads, Documents, Desktop)")
+      AnalyticsService.shared.capture(
+        "timeline_export_failed", ["source": "deeplink", "error": "destination_not_allowed"])
+      return
+    }
 
     do {
       try FileManager.default.createDirectory(
@@ -46,8 +60,8 @@ enum TimelineExportService {
     AnalyticsService.shared.capture(
       "timeline_exported",
       [
-        "start_day": dayString(request.startDay),
-        "end_day": dayString(request.endDay),
+        "start_day": DateFormatter.yyyyMMdd.string(from: request.startDay),
+        "end_day": DateFormatter.yyyyMMdd.string(from: request.endDay),
         "day_count": output.dayCount,
         "activity_count": output.activityCount,
         "format": "markdown",
@@ -65,55 +79,68 @@ enum TimelineExportService {
 
   // MARK: - Pure helpers (unit tested)
 
-  /// Resolves the final file URL for the export.
+  /// The standard, safe export roots: the user's Downloads, Documents, and Desktop folders.
+  /// Deep-link exports are constrained to these (and their subfolders) so a hostile
+  /// `dayflow://export-timeline?path=...` cannot overwrite sensitive files (dotfiles,
+  /// `~/Library`, LaunchAgents) on this non-sandboxed app.
+  static func allowedExportRoots(fileManager: FileManager = .default) -> [URL] {
+    let searchPaths: [FileManager.SearchPathDirectory] = [
+      .downloadsDirectory, .documentDirectory, .desktopDirectory,
+    ]
+    return searchPaths.compactMap {
+      fileManager.urls(for: $0, in: .userDomainMask).first?.standardizedFileURL
+    }
+  }
+
+  /// Resolves the final file URL for the export, or `nil` when the request targets a location
+  /// outside `allowedExportRoots`.
   ///
   /// - `rawPath == nil`/empty → `<downloads>/<derived name>`.
   /// - `rawPath` is an existing directory (or ends with a path separator) → `<dir>/<derived name>`.
   /// - otherwise `rawPath` is the target file; a missing extension gets `.md` appended.
   ///
-  /// A leading `~` is expanded. `fileManager` is injectable so tests can stub the home/Downloads
-  /// directory and the directory-existence check.
+  /// A leading `~` is expanded and `..` is collapsed (the URL is standardized) before the
+  /// containment check, so traversal cannot escape the allowed roots. `fileManager` is
+  /// injectable so tests can stub the export folders and the directory-existence check.
   static func resolveDestination(
     rawPath: String?,
     startDay: Date,
     endDay: Date,
     fileManager: FileManager = .default
-  ) -> URL {
-    let fileName = defaultFileName(startDay: startDay, endDay: endDay)
+  ) -> URL? {
+    let fileName = TimelineRangeExport.defaultFileName(startDay: startDay, endDay: endDay)
 
-    guard let rawPath, !rawPath.isEmpty else {
-      return downloadsDirectory(fileManager: fileManager).appendingPathComponent(fileName)
+    let candidate: URL
+    if let rawPath, !rawPath.isEmpty {
+      let expanded = (rawPath as NSString).expandingTildeInPath
+      let looksLikeDirectory =
+        rawPath.hasSuffix("/") || isExistingDirectory(expanded, fileManager: fileManager)
+      if looksLikeDirectory {
+        candidate = URL(fileURLWithPath: expanded, isDirectory: true)
+          .appendingPathComponent(fileName)
+      } else {
+        var fileURL = URL(fileURLWithPath: expanded)
+        if fileURL.pathExtension.isEmpty {
+          fileURL.appendPathExtension("md")
+        }
+        candidate = fileURL
+      }
+    } else {
+      candidate = downloadsDirectory(fileManager: fileManager).appendingPathComponent(fileName)
     }
 
-    let expanded = (rawPath as NSString).expandingTildeInPath
-    let looksLikeDirectory =
-      rawPath.hasSuffix("/") || isExistingDirectory(expanded, fileManager: fileManager)
-
-    if looksLikeDirectory {
-      return URL(fileURLWithPath: expanded, isDirectory: true).appendingPathComponent(fileName)
-    }
-
-    var fileURL = URL(fileURLWithPath: expanded)
-    if fileURL.pathExtension.isEmpty {
-      fileURL.appendPathExtension("md")
-    }
-    return fileURL
-  }
-
-  /// The default file name, mirroring the Settings UI export naming.
-  static func defaultFileName(startDay: Date, endDay: Date) -> String {
-    let start = dayString(startDay)
-    let end = dayString(endDay)
-    if start == end {
-      return "Dayflow timeline \(start).md"
-    }
-    return "Dayflow timeline \(start) to \(end).md"
+    let standardized = candidate.standardizedFileURL
+    guard isWithinAllowedRoots(standardized, fileManager: fileManager) else { return nil }
+    return standardized
   }
 
   // MARK: - Private
 
-  private static func dayString(_ date: Date) -> String {
-    DateFormatter.yyyyMMdd.string(from: date)
+  private static func isWithinAllowedRoots(_ url: URL, fileManager: FileManager) -> Bool {
+    let directoryPath = url.deletingLastPathComponent().standardizedFileURL.path
+    return allowedExportRoots(fileManager: fileManager).contains { root in
+      directoryPath == root.path || directoryPath.hasPrefix(root.path + "/")
+    }
   }
 
   private static func downloadsDirectory(fileManager: FileManager) -> URL {

--- a/Dayflow/Dayflow/App/TimelineExportService.swift
+++ b/Dayflow/Dayflow/App/TimelineExportService.swift
@@ -1,0 +1,131 @@
+import AppKit
+import Foundation
+
+/// Performs the side effects of a `dayflow://export-timeline` deep link: builds the Markdown
+/// for the requested range, resolves the destination path, writes the file, emits analytics,
+/// and optionally reveals the result in Finder.
+///
+/// The path/name resolution is factored into pure static helpers so it can be unit tested
+/// without touching the real filesystem.
+enum TimelineExportService {
+  /// Runs the export described by `request`. Intended to be called off the main actor
+  /// (the deep-link router dispatches it on a detached task). Fails soft: errors are logged
+  /// and reported to analytics, never thrown.
+  static func run(_ request: TimelineExportRequest, now: Date = Date()) {
+    let output = TimelineRangeExport.build(
+      startDay: request.startDay,
+      endDay: request.endDay,
+      now: now
+    )
+
+    let destination = resolveDestination(
+      rawPath: request.destinationPath,
+      startDay: request.startDay,
+      endDay: request.endDay
+    )
+
+    do {
+      try FileManager.default.createDirectory(
+        at: destination.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+      )
+      try output.markdown.write(to: destination, atomically: true, encoding: .utf8)
+    } catch {
+      print("[DeepLink] export-timeline: write failed: \(error.localizedDescription)")
+      AnalyticsService.shared.capture(
+        "timeline_export_failed",
+        ["source": "deeplink", "error": error.localizedDescription])
+      return
+    }
+
+    print(
+      "[DeepLink] export-timeline: wrote \(output.activityCount) "
+        + "activit\(output.activityCount == 1 ? "y" : "ies") across "
+        + "\(output.dayCount) day\(output.dayCount == 1 ? "" : "s") to \(destination.path)")
+
+    AnalyticsService.shared.capture(
+      "timeline_exported",
+      [
+        "start_day": dayString(request.startDay),
+        "end_day": dayString(request.endDay),
+        "day_count": output.dayCount,
+        "activity_count": output.activityCount,
+        "format": "markdown",
+        "file_extension": destination.pathExtension.lowercased(),
+        "source": "deeplink",
+      ])
+
+    if request.reveal {
+      let revealURL = destination
+      Task { @MainActor in
+        NSWorkspace.shared.activateFileViewerSelecting([revealURL])
+      }
+    }
+  }
+
+  // MARK: - Pure helpers (unit tested)
+
+  /// Resolves the final file URL for the export.
+  ///
+  /// - `rawPath == nil`/empty → `<downloads>/<derived name>`.
+  /// - `rawPath` is an existing directory (or ends with a path separator) → `<dir>/<derived name>`.
+  /// - otherwise `rawPath` is the target file; a missing extension gets `.md` appended.
+  ///
+  /// A leading `~` is expanded. `fileManager` is injectable so tests can stub the home/Downloads
+  /// directory and the directory-existence check.
+  static func resolveDestination(
+    rawPath: String?,
+    startDay: Date,
+    endDay: Date,
+    fileManager: FileManager = .default
+  ) -> URL {
+    let fileName = defaultFileName(startDay: startDay, endDay: endDay)
+
+    guard let rawPath, !rawPath.isEmpty else {
+      return downloadsDirectory(fileManager: fileManager).appendingPathComponent(fileName)
+    }
+
+    let expanded = (rawPath as NSString).expandingTildeInPath
+    let looksLikeDirectory =
+      rawPath.hasSuffix("/") || isExistingDirectory(expanded, fileManager: fileManager)
+
+    if looksLikeDirectory {
+      return URL(fileURLWithPath: expanded, isDirectory: true).appendingPathComponent(fileName)
+    }
+
+    var fileURL = URL(fileURLWithPath: expanded)
+    if fileURL.pathExtension.isEmpty {
+      fileURL.appendPathExtension("md")
+    }
+    return fileURL
+  }
+
+  /// The default file name, mirroring the Settings UI export naming.
+  static func defaultFileName(startDay: Date, endDay: Date) -> String {
+    let start = dayString(startDay)
+    let end = dayString(endDay)
+    if start == end {
+      return "Dayflow timeline \(start).md"
+    }
+    return "Dayflow timeline \(start) to \(end).md"
+  }
+
+  // MARK: - Private
+
+  private static func dayString(_ date: Date) -> String {
+    DateFormatter.yyyyMMdd.string(from: date)
+  }
+
+  private static func downloadsDirectory(fileManager: FileManager) -> URL {
+    if let url = fileManager.urls(for: .downloadsDirectory, in: .userDomainMask).first {
+      return url
+    }
+    return fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Downloads")
+  }
+
+  private static func isExistingDirectory(_ path: String, fileManager: FileManager) -> Bool {
+    var isDirectory: ObjCBool = false
+    let exists = fileManager.fileExists(atPath: path, isDirectory: &isDirectory)
+    return exists && isDirectory.boolValue
+  }
+}

--- a/Dayflow/Dayflow/Utilities/TimelineRangeExport.swift
+++ b/Dayflow/Dayflow/Utilities/TimelineRangeExport.swift
@@ -53,4 +53,15 @@ enum TimelineRangeExport {
       activityCount: totalActivities
     )
   }
+
+  /// The default export file name for a day or range. Shared by the Settings UI save panel
+  /// and the deep-link export so both propose the same name.
+  static func defaultFileName(startDay: Date, endDay: Date) -> String {
+    let start = DateFormatter.yyyyMMdd.string(from: startDay)
+    let end = DateFormatter.yyyyMMdd.string(from: endDay)
+    if start == end {
+      return "Dayflow timeline \(start).md"
+    }
+    return "Dayflow timeline \(start) to \(end).md"
+  }
 }

--- a/Dayflow/Dayflow/Utilities/TimelineRangeExport.swift
+++ b/Dayflow/Dayflow/Utilities/TimelineRangeExport.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Builds the Markdown export for an inclusive range of timeline days.
+///
+/// Shared by the Settings UI export (`OtherSettingsViewModel.exportTimelineRange`)
+/// and the `dayflow://export-timeline` deep link so both surfaces produce identical
+/// output from a single source of truth.
+enum TimelineRangeExport {
+  /// Divider inserted between per-day Markdown sections.
+  static let dayDivider = "\n\n---\n\n"
+
+  struct Output {
+    let markdown: String
+    let dayCount: Int
+    let activityCount: Int
+  }
+
+  /// Builds the combined Markdown for every day in `startDay...endDay` (inclusive).
+  ///
+  /// - Parameters:
+  ///   - startDay: First timeline day to include. Caller guarantees `startDay <= endDay`.
+  ///   - endDay: Last timeline day to include.
+  ///   - now: Reference date used by the formatter for relative day labels (e.g. "Today").
+  ///   - fetch: Returns the timeline cards for a `yyyy-MM-dd` day string. Defaults to
+  ///     `StorageManager.shared`; injectable so the day-iteration logic is unit-testable.
+  static func build(
+    startDay: Date,
+    endDay: Date,
+    now: Date = Date(),
+    fetch: (String) -> [TimelineCard] = { StorageManager.shared.fetchTimelineCards(forDay: $0) }
+  ) -> Output {
+    let calendar = Calendar.current
+
+    var cursor = startDay
+    var sections: [String] = []
+    var totalActivities = 0
+    var dayCount = 0
+
+    while cursor <= endDay {
+      let dayString = DateFormatter.yyyyMMdd.string(from: cursor)
+      let cards = fetch(dayString)
+      totalActivities += cards.count
+      sections.append(TimelineClipboardFormatter.makeMarkdown(for: cursor, cards: cards, now: now))
+      dayCount += 1
+
+      guard let next = calendar.date(byAdding: .day, value: 1, to: cursor) else { break }
+      cursor = next
+    }
+
+    return Output(
+      markdown: sections.joined(separator: dayDivider),
+      dayCount: dayCount,
+      activityCount: totalActivities
+    )
+  }
+}

--- a/Dayflow/Dayflow/Views/UI/Settings/OtherSettingsViewModel.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/OtherSettingsViewModel.swift
@@ -103,39 +103,15 @@ final class OtherSettingsViewModel: ObservableObject {
     exportErrorMessage = nil
 
     Task.detached(priority: .userInitiated) { [start, end] in
-      let calendar = Calendar.current
-      let dayFormatter = DateFormatter()
-      dayFormatter.dateFormat = "yyyy-MM-dd"
-
-      var cursor = start
-      let endDate = end
-
-      var sections: [String] = []
-      var totalActivities = 0
-      var dayCount = 0
-
-      while cursor <= endDate {
-        let dayString = dayFormatter.string(from: cursor)
-        let cards = StorageManager.shared.fetchTimelineCards(forDay: dayString)
-        totalActivities += cards.count
-        let section = TimelineClipboardFormatter.makeMarkdown(for: cursor, cards: cards)
-        sections.append(section)
-        dayCount += 1
-
-        guard let next = calendar.date(byAdding: .day, value: 1, to: cursor) else { break }
-        cursor = next
-      }
-
-      let divider = "\n\n---\n\n"
-      let exportText = sections.joined(separator: divider)
+      let output = TimelineRangeExport.build(startDay: start, endDay: end)
 
       await MainActor.run {
         self.presentSavePanelAndWrite(
-          exportText: exportText,
+          exportText: output.markdown,
           startDate: start,
           endDate: end,
-          dayCount: dayCount,
-          activityCount: totalActivities
+          dayCount: output.dayCount,
+          activityCount: output.activityCount
         )
       }
     }
@@ -218,6 +194,7 @@ final class OtherSettingsViewModel: ObservableObject {
           "activity_count": activityCount,
           "format": "markdown",
           "file_extension": url.pathExtension.lowercased(),
+          "source": "ui",
         ])
     } catch {
       exportStatusMessage = nil

--- a/Dayflow/Dayflow/Views/UI/Settings/OtherSettingsViewModel.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/OtherSettingsViewModel.swift
@@ -158,14 +158,11 @@ final class OtherSettingsViewModel: ObservableObject {
     dayCount: Int,
     activityCount: Int
   ) {
-    let dayFormatter = DateFormatter()
-    dayFormatter.dateFormat = "yyyy-MM-dd"
-
     let savePanel = NSSavePanel()
     savePanel.title = "Export timeline"
     savePanel.prompt = "Export"
     savePanel.nameFieldStringValue =
-      "Dayflow timeline \(dayFormatter.string(from: startDate)) to \(dayFormatter.string(from: endDate)).md"
+      TimelineRangeExport.defaultFileName(startDay: startDate, endDay: endDate)
     savePanel.allowedContentTypes = [.text, .plainText]
     savePanel.canCreateDirectories = true
 
@@ -188,8 +185,8 @@ final class OtherSettingsViewModel: ObservableObject {
       AnalyticsService.shared.capture(
         "timeline_exported",
         [
-          "start_day": dayFormatter.string(from: startDate),
-          "end_day": dayFormatter.string(from: endDate),
+          "start_day": DateFormatter.yyyyMMdd.string(from: startDate),
+          "end_day": DateFormatter.yyyyMMdd.string(from: endDate),
           "day_count": dayCount,
           "activity_count": activityCount,
           "format": "markdown",

--- a/Dayflow/DayflowTests/TimelineExportRequestTests.swift
+++ b/Dayflow/DayflowTests/TimelineExportRequestTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+
+@testable import Dayflow
+
+final class TimelineExportRequestTests: XCTestCase {
+  /// Fixed reference "now": 2026-06-15 12:00 local (hour >= 4 so the 4am rollback never fires).
+  private let now: Date = {
+    var components = DateComponents()
+    components.year = 2026
+    components.month = 6
+    components.day = 15
+    components.hour = 12
+    return Calendar.current.date(from: components)!
+  }()
+
+  // MARK: - Date selection
+
+  func testDateTodayExportsSingleTimelineDay() {
+    let request = try! parse("dayflow://export-timeline?date=today")
+    let today = timelineDisplayDate(from: now, now: now)
+    XCTAssertEqual(request.startDay, today)
+    XCTAssertEqual(request.endDay, today)
+  }
+
+  func testDateYesterdayIsOneDayBeforeToday() {
+    let request = try! parse("dayflow://export-timeline?date=yesterday")
+    let expected = Calendar.current.date(
+      byAdding: .day, value: -1, to: timelineDisplayDate(from: now, now: now))!
+    XCTAssertEqual(request.startDay, expected)
+    XCTAssertEqual(request.endDay, expected)
+  }
+
+  func testExplicitDateIsNormalizedToTimelineDay() {
+    let request = try! parse("dayflow://export-timeline?date=2026-06-10")
+    let expected = normalizedTimelineDate(DateFormatter.yyyyMMdd.date(from: "2026-06-10")!)
+    XCTAssertEqual(request.startDay, expected)
+    XCTAssertEqual(request.endDay, expected)
+  }
+
+  func testRangeUsesStartAndEnd() {
+    let request = try! parse("dayflow://export-timeline?start=2026-06-01&end=2026-06-03")
+    XCTAssertEqual(request.startDay, normalizedTimelineDate(date("2026-06-01")))
+    XCTAssertEqual(request.endDay, normalizedTimelineDate(date("2026-06-03")))
+  }
+
+  func testRangeWithOnlyStartFallsBackToStartForEnd() {
+    let request = try! parse("dayflow://export-timeline?start=2026-06-01")
+    let expected = normalizedTimelineDate(date("2026-06-01"))
+    XCTAssertEqual(request.startDay, expected)
+    XCTAssertEqual(request.endDay, expected)
+  }
+
+  func testNoParametersDefaultsToToday() {
+    let request = try! parse("dayflow://export-timeline")
+    let today = timelineDisplayDate(from: now, now: now)
+    XCTAssertEqual(request.startDay, today)
+    XCTAssertEqual(request.endDay, today)
+  }
+
+  func testKeysAreCaseInsensitive() {
+    let request = try! parse("dayflow://export-timeline?Start=2026-06-01&END=2026-06-02")
+    XCTAssertEqual(request.startDay, normalizedTimelineDate(date("2026-06-01")))
+    XCTAssertEqual(request.endDay, normalizedTimelineDate(date("2026-06-02")))
+  }
+
+  // MARK: - Validation
+
+  func testStartAfterEndFails() {
+    let result = TimelineExportRequest.parse(
+      url: URL(string: "dayflow://export-timeline?start=2026-06-05&end=2026-06-01")!, now: now)
+    XCTAssertEqual(result, .failure(.startAfterEnd))
+  }
+
+  func testInvalidCalendarDateFails() {
+    let result = TimelineExportRequest.parse(
+      url: URL(string: "dayflow://export-timeline?date=2026-13-40")!, now: now)
+    XCTAssertEqual(result, .failure(.invalidDate("2026-13-40")))
+  }
+
+  func testGarbageDateFails() {
+    let result = TimelineExportRequest.parse(
+      url: URL(string: "dayflow://export-timeline?date=garbage")!, now: now)
+    XCTAssertEqual(result, .failure(.invalidDate("garbage")))
+  }
+
+  // MARK: - Destination & flags
+
+  func testDestinationPathCaptured() {
+    let request = try! parse("dayflow://export-timeline?date=today&path=~/Reports/x.md")
+    XCTAssertEqual(request.destinationPath, "~/Reports/x.md")
+  }
+
+  func testDestinationAliasesHonored() {
+    let viaTo = try! parse("dayflow://export-timeline?date=today&to=/tmp/a.md")
+    XCTAssertEqual(viaTo.destinationPath, "/tmp/a.md")
+    let viaDestination = try! parse("dayflow://export-timeline?date=today&destination=/tmp/b.md")
+    XCTAssertEqual(viaDestination.destinationPath, "/tmp/b.md")
+  }
+
+  func testDestinationDefaultsToNil() {
+    let request = try! parse("dayflow://export-timeline?date=today")
+    XCTAssertNil(request.destinationPath)
+  }
+
+  func testRevealParsing() {
+    XCTAssertTrue(try! parse("dayflow://export-timeline?date=today&reveal=true").reveal)
+    XCTAssertTrue(try! parse("dayflow://export-timeline?date=today&reveal=1").reveal)
+    XCTAssertFalse(try! parse("dayflow://export-timeline?date=today&reveal=false").reveal)
+    XCTAssertFalse(try! parse("dayflow://export-timeline?date=today").reveal)
+  }
+
+  // MARK: - Helpers
+
+  private func parse(_ string: String) throws -> TimelineExportRequest {
+    let result = TimelineExportRequest.parse(url: URL(string: string)!, now: now)
+    switch result {
+    case .success(let request):
+      return request
+    case .failure(let error):
+      throw error
+    }
+  }
+
+  private func date(_ string: String) -> Date {
+    DateFormatter.yyyyMMdd.date(from: string)!
+  }
+}

--- a/Dayflow/DayflowTests/TimelineExportRequestTests.swift
+++ b/Dayflow/DayflowTests/TimelineExportRequestTests.swift
@@ -50,6 +50,13 @@ final class TimelineExportRequestTests: XCTestCase {
     XCTAssertEqual(request.endDay, expected)
   }
 
+  func testRangeWithOnlyEndFallsBackToEndForStart() {
+    let request = try! parse("dayflow://export-timeline?end=2026-06-03")
+    let expected = normalizedTimelineDate(date("2026-06-03"))
+    XCTAssertEqual(request.startDay, expected)
+    XCTAssertEqual(request.endDay, expected)
+  }
+
   func testNoParametersDefaultsToToday() {
     let request = try! parse("dayflow://export-timeline")
     let today = timelineDisplayDate(from: now, now: now)
@@ -83,6 +90,20 @@ final class TimelineExportRequestTests: XCTestCase {
     XCTAssertEqual(result, .failure(.invalidDate("garbage")))
   }
 
+  func testRangeExceedingCapFails() {
+    let result = TimelineExportRequest.parse(
+      url: URL(string: "dayflow://export-timeline?start=2000-01-01&end=2030-01-01")!, now: now)
+    XCTAssertEqual(result, .failure(.rangeTooLarge))
+  }
+
+  func testFullYearRangeIsAllowed() {
+    let result = TimelineExportRequest.parse(
+      url: URL(string: "dayflow://export-timeline?start=2026-01-01&end=2026-12-31")!, now: now)
+    guard case .success = result else {
+      return XCTFail("A one-year range should be within the cap, got \(result)")
+    }
+  }
+
   // MARK: - Destination & flags
 
   func testDestinationPathCaptured() {
@@ -105,8 +126,16 @@ final class TimelineExportRequestTests: XCTestCase {
   func testRevealParsing() {
     XCTAssertTrue(try! parse("dayflow://export-timeline?date=today&reveal=true").reveal)
     XCTAssertTrue(try! parse("dayflow://export-timeline?date=today&reveal=1").reveal)
+    XCTAssertTrue(try! parse("dayflow://export-timeline?date=today&reveal=yes").reveal)
+    XCTAssertTrue(try! parse("dayflow://export-timeline?date=today&reveal=YES").reveal)
     XCTAssertFalse(try! parse("dayflow://export-timeline?date=today&reveal=false").reveal)
     XCTAssertFalse(try! parse("dayflow://export-timeline?date=today").reveal)
+  }
+
+  func testDestinationAliasPrefersPathOverTo() {
+    // `to` appears first in the query but `path` is the primary key and must win.
+    let request = try! parse("dayflow://export-timeline?date=today&to=/tmp/a.md&path=/tmp/b.md")
+    XCTAssertEqual(request.destinationPath, "/tmp/b.md")
   }
 
   // MARK: - Helpers

--- a/Dayflow/DayflowTests/TimelineExportRouterTests.swift
+++ b/Dayflow/DayflowTests/TimelineExportRouterTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+@testable import Dayflow
+
+@MainActor
+final class TimelineExportRouterTests: XCTestCase {
+  func testExportTimelineActionResolvesFromIdentifierAndAlias() {
+    XCTAssertEqual(AppDeepLinkRouter.Action(identifier: "export-timeline"), .exportTimeline)
+    XCTAssertEqual(AppDeepLinkRouter.Action(identifier: "export"), .exportTimeline)
+    XCTAssertEqual(AppDeepLinkRouter.Action(identifier: "EXPORT-TIMELINE"), .exportTimeline)
+  }
+
+  func testUnknownActionDoesNotResolve() {
+    XCTAssertNil(AppDeepLinkRouter.Action(identifier: "bogus"))
+  }
+
+  func testExistingActionsStillResolve() {
+    XCTAssertEqual(AppDeepLinkRouter.Action(identifier: "start-recording"), .startRecording)
+    XCTAssertEqual(AppDeepLinkRouter.Action(identifier: "stop"), .stopRecording)
+  }
+}

--- a/Dayflow/DayflowTests/TimelineExportServiceTests.swift
+++ b/Dayflow/DayflowTests/TimelineExportServiceTests.swift
@@ -4,89 +4,108 @@ import XCTest
 
 final class TimelineExportServiceTests: XCTestCase {
   private let day = DateFormatter.yyyyMMdd.date(from: "2026-06-10")!
-  private let rangeEnd = DateFormatter.yyyyMMdd.date(from: "2026-06-03")!
-  private let rangeStart = DateFormatter.yyyyMMdd.date(from: "2026-06-01")!
+  /// Synthetic home so the allowed export roots are deterministic.
+  private let home = URL(fileURLWithPath: "/Users/test", isDirectory: true)
 
-  // MARK: - File name
-
-  func testDefaultFileNameSingleDay() {
-    let name = TimelineExportService.defaultFileName(startDay: day, endDay: day)
-    XCTAssertEqual(name, "Dayflow timeline 2026-06-10.md")
+  private func fm(existingDirectories: [String] = []) -> StubFileManager {
+    StubFileManager(home: home, existingDirectories: existingDirectories)
   }
 
-  func testDefaultFileNameRange() {
-    let name = TimelineExportService.defaultFileName(startDay: rangeStart, endDay: rangeEnd)
-    XCTAssertEqual(name, "Dayflow timeline 2026-06-01 to 2026-06-03.md")
-  }
-
-  // MARK: - Destination resolution
+  // MARK: - Allowed destinations
 
   func testNilPathUsesDownloadsDirectory() {
-    let fm = StubFileManager(downloads: URL(fileURLWithPath: "/Users/test/Downloads", isDirectory: true))
     let url = TimelineExportService.resolveDestination(
-      rawPath: nil, startDay: day, endDay: day, fileManager: fm)
-    XCTAssertEqual(url.path, "/Users/test/Downloads/Dayflow timeline 2026-06-10.md")
+      rawPath: nil, startDay: day, endDay: day, fileManager: fm())
+    XCTAssertEqual(url?.path, "/Users/test/Downloads/Dayflow timeline 2026-06-10.md")
   }
 
-  func testTrailingSlashTreatedAsDirectory() {
+  func testTrailingSlashTreatedAsDirectoryWithinAllowedRoot() {
     let url = TimelineExportService.resolveDestination(
-      rawPath: "/tmp/exports/", startDay: day, endDay: day, fileManager: StubFileManager())
-    XCTAssertEqual(url.path, "/tmp/exports/Dayflow timeline 2026-06-10.md")
+      rawPath: "/Users/test/Documents/exports/", startDay: day, endDay: day, fileManager: fm())
+    XCTAssertEqual(url?.path, "/Users/test/Documents/exports/Dayflow timeline 2026-06-10.md")
   }
 
   func testExistingDirectoryGetsDerivedFileName() {
-    let fm = StubFileManager(directories: ["/tmp/exports"])
     let url = TimelineExportService.resolveDestination(
-      rawPath: "/tmp/exports", startDay: day, endDay: day, fileManager: fm)
-    XCTAssertEqual(url.path, "/tmp/exports/Dayflow timeline 2026-06-10.md")
+      rawPath: "/Users/test/Desktop/reports", startDay: day, endDay: day,
+      fileManager: fm(existingDirectories: ["/Users/test/Desktop/reports"]))
+    XCTAssertEqual(url?.path, "/Users/test/Desktop/reports/Dayflow timeline 2026-06-10.md")
   }
 
   func testFilePathWithoutExtensionGetsMarkdownExtension() {
     let url = TimelineExportService.resolveDestination(
-      rawPath: "/tmp/myexport", startDay: day, endDay: day, fileManager: StubFileManager())
-    XCTAssertEqual(url.path, "/tmp/myexport.md")
+      rawPath: "/Users/test/Documents/myexport", startDay: day, endDay: day, fileManager: fm())
+    XCTAssertEqual(url?.path, "/Users/test/Documents/myexport.md")
   }
 
   func testFilePathWithExtensionUnchanged() {
     let url = TimelineExportService.resolveDestination(
-      rawPath: "/tmp/myexport.md", startDay: day, endDay: day, fileManager: StubFileManager())
-    XCTAssertEqual(url.path, "/tmp/myexport.md")
+      rawPath: "/Users/test/Downloads/myexport.md", startDay: day, endDay: day, fileManager: fm())
+    XCTAssertEqual(url?.path, "/Users/test/Downloads/myexport.md")
   }
 
-  func testTildeIsExpanded() {
+  func testTildeIsExpandedWithinDownloads() {
+    // Tilde expansion uses the real home, so align the stub's roots to the real home.
+    let realHome = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+    let stub = StubFileManager(home: realHome)
     let url = TimelineExportService.resolveDestination(
-      rawPath: "~/exp.md", startDay: day, endDay: day, fileManager: StubFileManager())
-    XCTAssertFalse(url.path.hasPrefix("~"))
-    XCTAssertTrue(url.path.hasSuffix("/exp.md"))
+      rawPath: "~/Downloads/exp.md", startDay: day, endDay: day, fileManager: stub)
+    XCTAssertEqual(url?.path, NSHomeDirectory() + "/Downloads/exp.md")
+  }
+
+  // MARK: - Rejected destinations (security: arbitrary-write guard)
+
+  func testPathOutsideAllowedRootsIsRejected() {
+    let url = TimelineExportService.resolveDestination(
+      rawPath: "/tmp/evil.md", startDay: day, endDay: day, fileManager: fm())
+    XCTAssertNil(url)
+  }
+
+  func testDotfileInHomeRootIsRejected() {
+    let url = TimelineExportService.resolveDestination(
+      rawPath: "/Users/test/.zshrc", startDay: day, endDay: day, fileManager: fm())
+    XCTAssertNil(url)
+  }
+
+  func testParentTraversalEscapingAllowedRootIsRejected() {
+    let url = TimelineExportService.resolveDestination(
+      rawPath: "/Users/test/Documents/../../etc/passwd", startDay: day, endDay: day,
+      fileManager: fm())
+    XCTAssertNil(url)
   }
 }
 
-/// Minimal `FileManager` stub: returns a fixed Downloads directory and reports a configured
-/// set of paths as existing directories. Everything else falls through to the real manager.
+/// Minimal `FileManager` stub: derives Downloads/Documents/Desktop from a fixed home and reports
+/// a configured set of paths as existing directories. Everything else falls through to the real
+/// manager.
 private final class StubFileManager: FileManager {
-  private let downloads: URL?
-  private let directories: Set<String>
+  private let home: URL
+  private let existingDirectories: Set<String>
 
-  init(downloads: URL? = nil, directories: [String] = []) {
-    self.downloads = downloads
-    self.directories = Set(directories)
+  init(home: URL, existingDirectories: [String] = []) {
+    self.home = home
+    self.existingDirectories = Set(existingDirectories)
     super.init()
   }
+
+  override var homeDirectoryForCurrentUser: URL { home }
 
   override func urls(
     for directory: FileManager.SearchPathDirectory,
     in domainMask: FileManager.SearchPathDomainMask
   ) -> [URL] {
-    if directory == .downloadsDirectory, let downloads {
-      return [downloads]
+    switch directory {
+    case .downloadsDirectory: return [home.appendingPathComponent("Downloads")]
+    case .documentDirectory: return [home.appendingPathComponent("Documents")]
+    case .desktopDirectory: return [home.appendingPathComponent("Desktop")]
+    default: return super.urls(for: directory, in: domainMask)
     }
-    return super.urls(for: directory, in: domainMask)
   }
 
   override func fileExists(
     atPath path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?
   ) -> Bool {
-    if directories.contains(path) {
+    if existingDirectories.contains(path) {
       isDirectory?.pointee = ObjCBool(true)
       return true
     }

--- a/Dayflow/DayflowTests/TimelineExportServiceTests.swift
+++ b/Dayflow/DayflowTests/TimelineExportServiceTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+
+@testable import Dayflow
+
+final class TimelineExportServiceTests: XCTestCase {
+  private let day = DateFormatter.yyyyMMdd.date(from: "2026-06-10")!
+  private let rangeEnd = DateFormatter.yyyyMMdd.date(from: "2026-06-03")!
+  private let rangeStart = DateFormatter.yyyyMMdd.date(from: "2026-06-01")!
+
+  // MARK: - File name
+
+  func testDefaultFileNameSingleDay() {
+    let name = TimelineExportService.defaultFileName(startDay: day, endDay: day)
+    XCTAssertEqual(name, "Dayflow timeline 2026-06-10.md")
+  }
+
+  func testDefaultFileNameRange() {
+    let name = TimelineExportService.defaultFileName(startDay: rangeStart, endDay: rangeEnd)
+    XCTAssertEqual(name, "Dayflow timeline 2026-06-01 to 2026-06-03.md")
+  }
+
+  // MARK: - Destination resolution
+
+  func testNilPathUsesDownloadsDirectory() {
+    let fm = StubFileManager(downloads: URL(fileURLWithPath: "/Users/test/Downloads", isDirectory: true))
+    let url = TimelineExportService.resolveDestination(
+      rawPath: nil, startDay: day, endDay: day, fileManager: fm)
+    XCTAssertEqual(url.path, "/Users/test/Downloads/Dayflow timeline 2026-06-10.md")
+  }
+
+  func testTrailingSlashTreatedAsDirectory() {
+    let url = TimelineExportService.resolveDestination(
+      rawPath: "/tmp/exports/", startDay: day, endDay: day, fileManager: StubFileManager())
+    XCTAssertEqual(url.path, "/tmp/exports/Dayflow timeline 2026-06-10.md")
+  }
+
+  func testExistingDirectoryGetsDerivedFileName() {
+    let fm = StubFileManager(directories: ["/tmp/exports"])
+    let url = TimelineExportService.resolveDestination(
+      rawPath: "/tmp/exports", startDay: day, endDay: day, fileManager: fm)
+    XCTAssertEqual(url.path, "/tmp/exports/Dayflow timeline 2026-06-10.md")
+  }
+
+  func testFilePathWithoutExtensionGetsMarkdownExtension() {
+    let url = TimelineExportService.resolveDestination(
+      rawPath: "/tmp/myexport", startDay: day, endDay: day, fileManager: StubFileManager())
+    XCTAssertEqual(url.path, "/tmp/myexport.md")
+  }
+
+  func testFilePathWithExtensionUnchanged() {
+    let url = TimelineExportService.resolveDestination(
+      rawPath: "/tmp/myexport.md", startDay: day, endDay: day, fileManager: StubFileManager())
+    XCTAssertEqual(url.path, "/tmp/myexport.md")
+  }
+
+  func testTildeIsExpanded() {
+    let url = TimelineExportService.resolveDestination(
+      rawPath: "~/exp.md", startDay: day, endDay: day, fileManager: StubFileManager())
+    XCTAssertFalse(url.path.hasPrefix("~"))
+    XCTAssertTrue(url.path.hasSuffix("/exp.md"))
+  }
+}
+
+/// Minimal `FileManager` stub: returns a fixed Downloads directory and reports a configured
+/// set of paths as existing directories. Everything else falls through to the real manager.
+private final class StubFileManager: FileManager {
+  private let downloads: URL?
+  private let directories: Set<String>
+
+  init(downloads: URL? = nil, directories: [String] = []) {
+    self.downloads = downloads
+    self.directories = Set(directories)
+    super.init()
+  }
+
+  override func urls(
+    for directory: FileManager.SearchPathDirectory,
+    in domainMask: FileManager.SearchPathDomainMask
+  ) -> [URL] {
+    if directory == .downloadsDirectory, let downloads {
+      return [downloads]
+    }
+    return super.urls(for: directory, in: domainMask)
+  }
+
+  override func fileExists(
+    atPath path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?
+  ) -> Bool {
+    if directories.contains(path) {
+      isDirectory?.pointee = ObjCBool(true)
+      return true
+    }
+    isDirectory?.pointee = ObjCBool(false)
+    return false
+  }
+}

--- a/Dayflow/DayflowTests/TimelineRangeExportTests.swift
+++ b/Dayflow/DayflowTests/TimelineRangeExportTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+
+@testable import Dayflow
+
+final class TimelineRangeExportTests: XCTestCase {
+  func testSingleDayBuildsOneSectionWithAllCards() {
+    let day = normalizedDay("2026-06-10")
+    let cards = [
+      card(day: "2026-06-10", title: "Email"),
+      card(day: "2026-06-10", title: "Coding"),
+    ]
+
+    let output = TimelineRangeExport.build(
+      startDay: day,
+      endDay: day,
+      now: day,
+      fetch: { _ in cards }
+    )
+
+    XCTAssertEqual(output.dayCount, 1)
+    XCTAssertEqual(output.activityCount, 2)
+    XCTAssertTrue(output.markdown.contains("Email"))
+    XCTAssertTrue(output.markdown.contains("Coding"))
+    XCTAssertFalse(output.markdown.contains(TimelineRangeExport.dayDivider))
+  }
+
+  func testRangeJoinsSectionsAndCountsOnlyNonEmptyDays() {
+    let start = normalizedDay("2026-06-01")
+    let end = normalizedDay("2026-06-03")
+    let cardsByDay: [String: [TimelineCard]] = [
+      "2026-06-01": [card(day: "2026-06-01", title: "Day one")],
+      // 2026-06-02 intentionally empty
+      "2026-06-03": [
+        card(day: "2026-06-03", title: "Day three A"),
+        card(day: "2026-06-03", title: "Day three B"),
+      ],
+    ]
+
+    let output = TimelineRangeExport.build(
+      startDay: start,
+      endDay: end,
+      now: end,
+      fetch: { cardsByDay[$0] ?? [] }
+    )
+
+    XCTAssertEqual(output.dayCount, 3)
+    XCTAssertEqual(output.activityCount, 3)
+    // Two dividers between three day-sections.
+    let dividerCount = output.markdown.components(separatedBy: TimelineRangeExport.dayDivider).count - 1
+    XCTAssertEqual(dividerCount, 2)
+    XCTAssertTrue(output.markdown.contains("_No timeline activities were recorded for this day._"))
+  }
+
+  func testFetchInvokedWithSequentialDayStrings() {
+    let start = normalizedDay("2026-06-01")
+    let end = normalizedDay("2026-06-03")
+    var requestedDays: [String] = []
+
+    _ = TimelineRangeExport.build(
+      startDay: start,
+      endDay: end,
+      now: end,
+      fetch: { day in
+        requestedDays.append(day)
+        return []
+      }
+    )
+
+    XCTAssertEqual(requestedDays, ["2026-06-01", "2026-06-02", "2026-06-03"])
+  }
+
+  // MARK: - Fixtures
+
+  private func normalizedDay(_ string: String) -> Date {
+    normalizedTimelineDate(DateFormatter.yyyyMMdd.date(from: string)!)
+  }
+
+  private func card(day: String, title: String) -> TimelineCard {
+    TimelineCard(
+      recordId: nil,
+      batchId: nil,
+      startTimestamp: "09:00 AM",
+      endTimestamp: "09:30 AM",
+      category: "Focus",
+      subcategory: "Work",
+      title: title,
+      summary: "Summary for \(title)",
+      detailedSummary: "",
+      day: day,
+      distractions: nil,
+      videoSummaryURL: nil,
+      otherVideoSummaryURLs: nil,
+      appSites: nil
+    )
+  }
+}

--- a/Dayflow/DayflowTests/TimelineRangeExportTests.swift
+++ b/Dayflow/DayflowTests/TimelineRangeExportTests.swift
@@ -24,7 +24,7 @@ final class TimelineRangeExportTests: XCTestCase {
     XCTAssertFalse(output.markdown.contains(TimelineRangeExport.dayDivider))
   }
 
-  func testRangeJoinsSectionsAndCountsOnlyNonEmptyDays() {
+  func testRangeRendersEveryCalendarDayAndSumsActivities() {
     let start = normalizedDay("2026-06-01")
     let end = normalizedDay("2026-06-03")
     let cardsByDay: [String: [TimelineCard]] = [
@@ -43,12 +43,30 @@ final class TimelineRangeExportTests: XCTestCase {
       fetch: { cardsByDay[$0] ?? [] }
     )
 
+    // dayCount counts every calendar day in the range (including the empty one);
+    // activityCount sums only the cards that exist.
     XCTAssertEqual(output.dayCount, 3)
     XCTAssertEqual(output.activityCount, 3)
     // Two dividers between three day-sections.
     let dividerCount = output.markdown.components(separatedBy: TimelineRangeExport.dayDivider).count - 1
     XCTAssertEqual(dividerCount, 2)
     XCTAssertTrue(output.markdown.contains("_No timeline activities were recorded for this day._"))
+  }
+
+  // MARK: - Default file name
+
+  func testDefaultFileNameSingleDay() {
+    let single = normalizedDay("2026-06-10")
+    XCTAssertEqual(
+      TimelineRangeExport.defaultFileName(startDay: single, endDay: single),
+      "Dayflow timeline 2026-06-10.md")
+  }
+
+  func testDefaultFileNameRange() {
+    XCTAssertEqual(
+      TimelineRangeExport.defaultFileName(
+        startDay: normalizedDay("2026-06-01"), endDay: normalizedDay("2026-06-03")),
+      "Dayflow timeline 2026-06-01 to 2026-06-03.md")
   }
 
   func testFetchInvokedWithSequentialDayStrings() {

--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ Dayflow registers a `dayflow://` URL scheme so you can drive it from Raycast, Al
 | `date` | `today`, `yesterday`, or `YYYY-MM-DD` (single day) | `today` |
 | `start` / `end` | `today`, `yesterday`, or `YYYY-MM-DD` (inclusive range) | — |
 | `path` (aliases `to`, `destination`) | a file path, or a directory to write into; `~` is expanded | `~/Downloads/Dayflow timeline <range>.md` |
-| `reveal` | `true` / `1` to reveal the file in Finder when done | `false` |
+| `reveal` | `true` / `1` / `yes` to reveal the file in Finder when done | `false` |
+
+For safety (the `dayflow://` scheme can be invoked by other apps), deep-link exports may only be written inside your **Downloads**, **Documents**, or **Desktop** folders (or a subfolder of one); a `path` outside those is rejected and nothing is written. Exports are also capped at one year (366 days) per call.
 
 ```bash
 # Export today to ~/Downloads

--- a/README.md
+++ b/README.md
@@ -76,6 +76,41 @@ Most time trackers tell you which app was open. Dayflow tries to understand what
 
 Cursor for two hours could mean shipping a feature, debugging auth, reviewing a PR, or getting lost in setup. Dayflow gives you the context, not just the window title.
 
+## Automation
+
+Dayflow registers a `dayflow://` URL scheme so you can drive it from Raycast, Alfred, Apple Shortcuts, `cron`, or any tool that can open a URL (`open "dayflow://…"`).
+
+### Export the timeline
+
+`dayflow://export-timeline` writes your timeline to a Markdown file without opening the app UI — the same output as the in-app export, but scriptable.
+
+| Parameter | Values | Default |
+| --- | --- | --- |
+| `date` | `today`, `yesterday`, or `YYYY-MM-DD` (single day) | `today` |
+| `start` / `end` | `today`, `yesterday`, or `YYYY-MM-DD` (inclusive range) | — |
+| `path` (aliases `to`, `destination`) | a file path, or a directory to write into; `~` is expanded | `~/Downloads/Dayflow timeline <range>.md` |
+| `reveal` | `true` / `1` to reveal the file in Finder when done | `false` |
+
+```bash
+# Export today to ~/Downloads
+open "dayflow://export-timeline?date=today"
+
+# Export a date range to a specific file
+open "dayflow://export-timeline?start=2026-06-01&end=2026-06-07&path=~/Reports/last-week.md"
+
+# Export yesterday into a folder and reveal it in Finder
+open "dayflow://export-timeline?date=yesterday&path=~/Reports/&reveal=true"
+```
+
+Dates follow Dayflow's timeline day, which runs from 4am to 4am — so before 4am, `date=today` exports the day that just ended.
+
+### Control recording
+
+```bash
+open "dayflow://start-recording"   # aliases: start, resume
+open "dayflow://stop-recording"    # aliases: stop, pause
+```
+
 ## Privacy
 
 Dayflow is local-first and open source.


### PR DESCRIPTION
# feat: Deep-link timeline export (`dayflow://export-timeline`)

> [!NOTE]
> I'm not used to swift apps, this code change is mainly done using AI. I tested it, it seems to be good, my main concern is about the path you pass to the `.md` artifact. basically we just allow it to drop it in allowed paths, maybe we could not give choice and send it to `Downloads`.

Closes #178.

## What

Adds a non-interactive deep-link action that exports the Dayflow timeline to a Markdown file, so it can be triggered from Raycast, Alfred, Apple Shortcuts, or cron — closing the gap in #178 (today the Markdown export is only reachable through Settings, which opens an interactive `NSSavePanel`, while recording start/stop is already automatable via deep links).

```bash
# Export today to ~/Downloads
open "dayflow://export-timeline?date=today"

# Export a date range to a specific file
open "dayflow://export-timeline?start=2026-06-01&end=2026-06-07&path=~/Documents/last-week.md"

# Export yesterday into a folder and reveal it in Finder
open "dayflow://export-timeline?date=yesterday&path=~/Documents/reports/&reveal=true"
```

**Parameters** (query keys, case-insensitive):

| Parameter | Values | Default |
| --- | --- | --- |
| `date` | `today`, `yesterday`, or `YYYY-MM-DD` (single day) | `today` |
| `start` / `end` | same grammar (inclusive range) | — |
| `path` (aliases `to`, `destination`) | a file path or a directory to write into; `~` expanded | `~/Downloads/Dayflow timeline <range>.md` |
| `reveal` | `true` / `1` / `yes` → reveal in Finder when done | `false` |

## How

- **`TimelineRangeExport`** (new) — the shared builder that turns a day range into Markdown + counts. Both the Settings UI export and the new deep link call it, so they produce identical output from one source of truth (it also now owns the shared `defaultFileName`).
- **`TimelineExportRequest`** (new) — a pure, fully unit-tested URL→parameters parser (no file or DB I/O). Returns a `Result` with typed errors.
- **`TimelineExportService`** (new) — the side effects: resolve the destination, write the file, emit analytics, optionally reveal in Finder.
- **`AppDeepLinkRouter`** — adds the `export-timeline` action (alias `export`) next to the existing `start-recording`/`stop-recording`/`referral` actions.
- **`OtherSettingsViewModel`** — refactored to call the shared builder (its inline day loop is gone).
- Reuses the existing `TimelineClipboardFormatter.makeMarkdown` and `timelineDisplayDate` (4am→4am timeline day). No `project.pbxproj` edits needed — the project uses file-system-synchronized groups.

## Security

The `dayflow://` scheme is invokable by any local app or webpage, and the app is not sandboxed. To prevent a hostile link from overwriting arbitrary files (`~/.zshrc`, `~/.ssh/config`, LaunchAgents) or exfiltrating the timeline:

- Deep-link exports are constrained to the user's **Downloads, Documents, and Desktop** folders (and subfolders). `..` is collapsed before the containment check; out-of-bounds paths are rejected and nothing is written.
- The export range is capped at **366 days** per call, so one link can't trigger thousands of background DB reads.
- The export runs on a background GCD queue (off the Swift cooperative thread pool) and fails soft (logged + a `timeline_export_failed` analytics event), never crashing.

The interactive Settings export is unchanged and still uses `NSSavePanel`.

## Tests

Build and Unit tests are passing.
No idea how to do the integration tests :/
