### PR TITLE
Add a floating focus Mini Timer

### DIFF
--- a/Dayflow/Dayflow/App/AppDelegate.swift
+++ b/Dayflow/Dayflow/App/AppDelegate.swift
@@ -156,6 +156,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // Start notification service for journal reminders
     NotificationService.shared.start()
 
+    // Start the productivity stats engine and restore the floating focus timer
+    // if the user previously enabled it.
+    ProductivityStats.shared.start()
+    MiniTimerWindowController.shared.restoreIfEnabled()
+
     // Start daily recap generation scheduler (checks every 5 minutes)
     DailyRecapScheduler.shared.start()
 

--- a/Dayflow/Dayflow/Core/Productivity/ProductivityPreferences.swift
+++ b/Dayflow/Dayflow/Core/Productivity/ProductivityPreferences.swift
@@ -1,0 +1,49 @@
+//
+//  ProductivityPreferences.swift
+//  Dayflow
+//
+//  UserDefaults-backed settings for the focus Mini Timer.
+//
+
+import Foundation
+
+enum ProductivityPreferences {
+  private static let defaults = UserDefaults.standard
+
+  // MARK: - Keys
+  private static let miniTimerEnabledKey = "miniTimerEnabled"
+  private static let miniTimerOriginXKey = "miniTimerOriginX"
+  private static let miniTimerOriginYKey = "miniTimerOriginY"
+
+  // MARK: - Mini Timer
+
+  /// Whether the floating focus timer is shown. Default off so the app stays
+  /// unobtrusive until the user opts in from the menu bar or Settings.
+  static var miniTimerEnabled: Bool {
+    get { defaults.bool(forKey: miniTimerEnabledKey) }
+    set { defaults.set(newValue, forKey: miniTimerEnabledKey) }
+  }
+
+  /// Saved bottom-left origin of the timer panel, or nil if never moved.
+  static var miniTimerOrigin: CGPoint? {
+    get {
+      guard
+        defaults.object(forKey: miniTimerOriginXKey) != nil,
+        defaults.object(forKey: miniTimerOriginYKey) != nil
+      else { return nil }
+      return CGPoint(
+        x: defaults.double(forKey: miniTimerOriginXKey),
+        y: defaults.double(forKey: miniTimerOriginYKey)
+      )
+    }
+    set {
+      if let point = newValue {
+        defaults.set(point.x, forKey: miniTimerOriginXKey)
+        defaults.set(point.y, forKey: miniTimerOriginYKey)
+      } else {
+        defaults.removeObject(forKey: miniTimerOriginXKey)
+        defaults.removeObject(forKey: miniTimerOriginYKey)
+      }
+    }
+  }
+}

--- a/Dayflow/Dayflow/Core/Productivity/ProductivityStats.swift
+++ b/Dayflow/Dayflow/Core/Productivity/ProductivityStats.swift
@@ -1,0 +1,132 @@
+//
+//  ProductivityStats.swift
+//  Dayflow
+//
+//  Aggregates today's processed timeline cards into a focused-time total and
+//  exposes a live-optimistic count-up for the focus Mini Timer.
+//
+//  Dayflow categorizes activity in batches (~15 min lag), so "live" here means:
+//  take everything already analyzed today, then optimistically extend the most
+//  recent focused segment forward to *now* while the user is actively at the
+//  machine (recording on, not paused, not idle). When the next batch lands, the
+//  processed total absorbs that gap and the live extension shrinks back.
+//
+//  All time math uses epoch start_ts/end_ts (ground truth), never the display
+//  "h:mm a" text.
+//
+
+import Combine
+import CoreGraphics
+import Foundation
+
+@MainActor
+final class ProductivityStats: ObservableObject {
+  static let shared = ProductivityStats()
+
+  /// Focused seconds from analyzed cards for the current (4 AM boundary) day.
+  @Published private(set) var focusedSecondsToday: Double = 0
+
+  /// End of the most recent analyzed card today, used to extend the live count.
+  private(set) var lastSegmentEnd: Date?
+  /// Whether that most recent segment was focused (so we keep counting up).
+  private(set) var lastSegmentIsFocused: Bool = false
+
+  /// Cap on the optimistic forward extension so a stalled analysis pipeline can't
+  /// run the counter away indefinitely (slightly above typical batch cadence).
+  private let liveExtensionCapSeconds: Double = 30 * 60
+  /// Treat the user as away after this much system-wide input inactivity.
+  private let idleThresholdSeconds: Double = 5 * 60
+
+  private var timer: Timer?
+  private var observer: NSObjectProtocol?
+
+  private init() {}
+
+  func start() {
+    recompute()
+    let timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+      Task { @MainActor in self?.recompute() }
+    }
+    self.timer = timer
+
+    observer = NotificationCenter.default.addObserver(
+      forName: .timelineDataUpdated,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      MainActor.assumeIsolated { self?.recompute() }
+    }
+  }
+
+  /// Focused seconds to display, including the live-optimistic extension.
+  func liveFocusedSeconds(asOf now: Date) -> Double {
+    focusedSecondsToday + liveExtensionSeconds(asOf: now)
+  }
+
+  /// Whether the timer is actively counting up right now (for the live dot).
+  func isActivelyCounting(asOf now: Date) -> Bool {
+    liveExtensionSeconds(asOf: now) > 0
+  }
+
+  private func liveExtensionSeconds(asOf now: Date) -> Double {
+    guard
+      lastSegmentIsFocused,
+      let end = lastSegmentEnd,
+      AppState.shared.isRecording,
+      !PauseManager.shared.isPaused,
+      !userIsIdle()
+    else { return 0 }
+    return min(max(0, now.timeIntervalSince(end)), liveExtensionCapSeconds)
+  }
+
+  /// System-wide input idle, via CGEventSource — no permission, no latch.
+  private func userIsIdle() -> Bool {
+    let types: [CGEventType] = [
+      .mouseMoved, .leftMouseDown, .rightMouseDown, .keyDown, .scrollWheel,
+    ]
+    let idle =
+      types
+      .map { CGEventSource.secondsSinceLastEventType(.combinedSessionState, eventType: $0) }
+      .min() ?? .greatestFiniteMagnitude
+    return idle >= idleThresholdSeconds
+  }
+
+  // MARK: - Recompute
+
+  private func recompute() {
+    let now = Date()
+    let dayInfo = now.getDayInfoFor4AMBoundary()
+    let spans = StorageManager.shared.fetchTimelineActivity(forDay: dayInfo.dayString)
+
+    let idleKey = normalizedCategoryKey(CategoryStore.shared.idleCategory?.name ?? "Idle")
+    let distractionKey = normalizedCategoryKey("Distraction")
+
+    var focused: Double = 0
+    var latestEnd: Date?
+    var latestIsFocused = false
+
+    for span in spans {
+      let duration = Double(span.endTs - span.startTs)
+      guard duration > 0 else { continue }
+
+      let categoryKey = normalizedCategoryKey(
+        span.category.trimmingCharacters(in: .whitespacesAndNewlines))
+      let isIdle = categoryKey == idleKey
+      let isDistraction = categoryKey == distractionKey
+
+      if !isIdle && !isDistraction {
+        focused += duration
+      }
+
+      let endDate = Date(timeIntervalSince1970: TimeInterval(span.endTs))
+      if latestEnd == nil || endDate > latestEnd! {
+        latestEnd = endDate
+        latestIsFocused = !isIdle && !isDistraction
+      }
+    }
+
+    focusedSecondsToday = focused
+    lastSegmentEnd = latestEnd
+    lastSegmentIsFocused = latestIsFocused
+  }
+}

--- a/Dayflow/Dayflow/Core/Recording/StorageManager+TimelineCards.swift
+++ b/Dayflow/Dayflow/Core/Recording/StorageManager+TimelineCards.swift
@@ -2,6 +2,13 @@ import Foundation
 import GRDB
 import Sentry
 
+/// Epoch-based activity span for a timeline card.
+struct TimelineActivitySpan: Sendable {
+  let category: String
+  let startTs: Int
+  let endTs: Int
+}
+
 extension StorageManager {
   func saveTimelineCardShell(batchId: Int64, card: TimelineCardShell) -> Int64? {
     let encoder = JSONEncoder()
@@ -387,6 +394,52 @@ extension StorageManager {
           )
         }
       }) ?? []
+  }
+
+  /// Lightweight epoch-based activity for a day, used by the focus timer.
+  /// Reads `start_ts`/`end_ts` (ground truth) rather than the display
+  /// `start`/`end` text, which can be timezone-skewed for some cards.
+  func fetchTimelineActivity(forDay day: String) -> [TimelineActivitySpan] {
+    guard let dayDate = dateFormatter.date(from: day) else { return [] }
+    let calendar = Calendar.current
+
+    var startComponents = calendar.dateComponents([.year, .month, .day], from: dayDate)
+    startComponents.hour = 4
+    startComponents.minute = 0
+    startComponents.second = 0
+    guard let dayStart = calendar.date(from: startComponents) else { return [] }
+
+    guard let nextDay = calendar.date(byAdding: .day, value: 1, to: dayDate) else { return [] }
+    var endComponents = calendar.dateComponents([.year, .month, .day], from: nextDay)
+    endComponents.hour = 4
+    endComponents.minute = 0
+    endComponents.second = 0
+    guard let dayEnd = calendar.date(from: endComponents) else { return [] }
+
+    let startTs = Int(dayStart.timeIntervalSince1970)
+    let endTs = Int(dayEnd.timeIntervalSince1970)
+
+    let spans: [TimelineActivitySpan]? = try? timedRead("fetchTimelineActivity(forDay:\(day))") {
+      db in
+      try Row.fetchAll(
+        db,
+        sql: """
+              SELECT category, start_ts, end_ts FROM timeline_cards
+              WHERE start_ts >= ? AND start_ts < ?
+                AND is_deleted = 0
+              ORDER BY end_ts ASC
+          """, arguments: [startTs, endTs]
+      )
+      .compactMap { row -> TimelineActivitySpan? in
+        guard
+          let category: String = row["category"],
+          let start: Int = row["start_ts"],
+          let end: Int = row["end_ts"]
+        else { return nil }
+        return TimelineActivitySpan(category: category, startTs: start, endTs: end)
+      }
+    }
+    return spans ?? []
   }
 
   func fetchTimelineCards(forDay day: String) -> [TimelineCard] {

--- a/Dayflow/Dayflow/Menu/StatusMenuView.swift
+++ b/Dayflow/Dayflow/Menu/StatusMenuView.swift
@@ -6,6 +6,7 @@ struct StatusMenuView: View {
   let dismissMenu: () -> Void
   @ObservedObject private var appState = AppState.shared
   @ObservedObject private var pauseManager = PauseManager.shared
+  @ObservedObject private var miniTimer = MiniTimerWindowController.shared
   private let updaterManager = UpdaterManager.shared
 
   private var controlMode: RecordingControlMode {
@@ -24,6 +25,10 @@ struct StatusMenuView: View {
       MenuDivider()
 
       MenuRow(title: "Open Dayflow", assetImage: "DayflowLogo", action: openDayflow)
+      MenuRow(
+        title: miniTimer.isVisible ? "Hide Focus Timer" : "Show Focus Timer",
+        systemImage: "timer",
+        action: toggleFocusTimer)
       MenuRow(title: "Open Recordings", action: openRecordingsFolder)
       MenuRow(title: "Check for Updates", action: checkForUpdates)
 
@@ -61,6 +66,10 @@ struct StatusMenuView: View {
       MainWindowController.shared.showMainWindow()
       NSApp.activate(ignoringOtherApps: true)
     }
+  }
+
+  private func toggleFocusTimer() {
+    miniTimer.toggle()
   }
 
   private func openRecordingsFolder() {

--- a/Dayflow/Dayflow/System/MiniTimerWindowController.swift
+++ b/Dayflow/Dayflow/System/MiniTimerWindowController.swift
@@ -1,0 +1,131 @@
+//
+//  MiniTimerWindowController.swift
+//  Dayflow
+//
+//  Manages the floating, always‑on‑top focus timer panel. Non‑activating so it
+//  never steals focus, joins all Spaces (incl. fullscreen), and is draggable.
+//
+
+import AppKit
+import Combine
+import SwiftUI
+
+@MainActor
+final class MiniTimerWindowController: NSObject, ObservableObject {
+  static let shared = MiniTimerWindowController()
+
+  /// Source of truth for whether the timer is on screen (drives menu/settings UI).
+  @Published private(set) var isVisible = false
+
+  private var panel: NSPanel?
+  private var moveObserver: NSObjectProtocol?
+
+  private override init() {
+    super.init()
+  }
+
+  /// Show the panel if the user previously enabled it.
+  func restoreIfEnabled() {
+    if ProductivityPreferences.miniTimerEnabled {
+      show(persist: false)
+    }
+  }
+
+  func toggle() {
+    isVisible ? hide() : show()
+  }
+
+  func setVisible(_ visible: Bool) {
+    visible ? show() : hide()
+  }
+
+  func show(persist: Bool = true) {
+    if persist { ProductivityPreferences.miniTimerEnabled = true }
+
+    if let panel {
+      panel.orderFrontRegardless()
+      isVisible = true
+      return
+    }
+
+    // Fixed-size hosting view. Do NOT use NSHostingController.sizingOptions /
+    // auto-sizing here: combined with a borderless movable panel it drove
+    // AppKit's constraint engine into infinite recursion (stack overflow).
+    let size = MiniTimerView.windowSize
+    let hosting = NSHostingView(
+      rootView: MiniTimerView(onClose: { [weak self] in self?.hide() }))
+    hosting.frame = NSRect(origin: .zero, size: size)
+
+    let panel = NSPanel(
+      contentRect: NSRect(origin: .zero, size: size),
+      styleMask: [.nonactivatingPanel, .borderless],
+      backing: .buffered,
+      defer: false)
+    panel.isFloatingPanel = true
+    panel.level = .floating
+    panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+    panel.backgroundColor = .clear
+    panel.isOpaque = false
+    panel.hasShadow = false  // the SwiftUI capsule draws its own shadow
+    panel.isMovableByWindowBackground = true
+    panel.hidesOnDeactivate = false
+    // Dayflow runs as a menu-bar (.accessory) app when the Dock icon is off.
+    // Accessory apps hide ALL their windows when not frontmost; canHide = false
+    // is the lever that keeps this panel on screen regardless of app focus.
+    panel.canHide = false
+    panel.contentView = hosting
+
+    positionPanel(panel, size: size)
+    panel.orderFrontRegardless()
+
+    moveObserver = NotificationCenter.default.addObserver(
+      forName: NSWindow.didMoveNotification,
+      object: panel,
+      queue: .main
+    ) { [weak self] _ in
+      MainActor.assumeIsolated { self?.saveOrigin() }
+    }
+
+    self.panel = panel
+    isVisible = true
+  }
+
+  func hide() {
+    ProductivityPreferences.miniTimerEnabled = false
+    if let moveObserver {
+      NotificationCenter.default.removeObserver(moveObserver)
+      self.moveObserver = nil
+    }
+    panel?.orderOut(nil)
+    panel = nil
+    isVisible = false
+  }
+
+  // MARK: - Positioning
+
+  private func positionPanel(_ panel: NSPanel, size: NSSize) {
+    if let saved = ProductivityPreferences.miniTimerOrigin,
+      isOriginOnScreen(saved, size: size)
+    {
+      panel.setFrameOrigin(saved)
+      return
+    }
+
+    // Default: top‑right of the main screen, just below the menu bar.
+    let screen = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+    let origin = CGPoint(
+      x: screen.maxX - size.width - 24,
+      y: screen.maxY - size.height - 24)
+    panel.setFrameOrigin(origin)
+  }
+
+  private func isOriginOnScreen(_ origin: CGPoint, size: NSSize) -> Bool {
+    let frame = CGRect(origin: origin, size: size)
+    return NSScreen.screens.contains { $0.visibleFrame.intersects(frame) }
+  }
+
+  private func saveOrigin() {
+    guard let panel else { return }
+    ProductivityPreferences.miniTimerOrigin = panel.frame.origin
+  }
+}

--- a/Dayflow/Dayflow/Views/UI/MiniTimer/MiniTimerView.swift
+++ b/Dayflow/Dayflow/Views/UI/MiniTimer/MiniTimerView.swift
@@ -1,0 +1,81 @@
+//
+//  MiniTimerView.swift
+//  Dayflow
+//
+//  The floating focus pill: today's focused time, counting up live.
+//
+//  NOTE: the view declares a FIXED outer frame. The hosting window is sized to
+//  match and does not auto-resize — earlier the dynamic/auto-sizing path drove
+//  AppKit's constraint engine into infinite recursion (stack-overflow crash).
+//
+
+import SwiftUI
+
+struct MiniTimerView: View {
+  static let windowSize = CGSize(width: 196, height: 52)
+
+  @ObservedObject private var stats = ProductivityStats.shared
+  var onClose: () -> Void
+
+  @State private var hovering = false
+
+  var body: some View {
+    // TimelineView ticks every second so the live-optimistic extension counts
+    // up smoothly between the once-a-minute processed refreshes.
+    TimelineView(.periodic(from: .now, by: 1)) { context in
+      pill(
+        focused: stats.liveFocusedSeconds(asOf: context.date),
+        counting: stats.isActivelyCounting(asOf: context.date))
+    }
+    .frame(width: Self.windowSize.width, height: Self.windowSize.height)
+    .onHover { isHovering in
+      withAnimation(.easeInOut(duration: 0.15)) { hovering = isHovering }
+    }
+  }
+
+  private func pill(focused: Double, counting: Bool) -> some View {
+    HStack(spacing: 8) {
+      Circle()
+        .fill(counting ? Color.green : Color.secondary.opacity(0.5))
+        .frame(width: 7, height: 7)
+
+      Text(Self.format(seconds: focused))
+        .font(.system(size: 14, weight: .semibold).monospacedDigit())
+        .foregroundStyle(.primary)
+
+      Spacer(minLength: 4)
+
+      if hovering {
+        Button(action: onClose) {
+          Image(systemName: "xmark")
+            .font(.system(size: 9, weight: .bold))
+            .foregroundStyle(.secondary)
+            .frame(width: 16, height: 16)
+            .background(Color.primary.opacity(0.08), in: Circle())
+        }
+        .buttonStyle(.plain)
+        .help("Hide the focus timer")
+      } else {
+        Text("focused")
+          .font(.system(size: 11, weight: .medium))
+          .foregroundStyle(.secondary)
+      }
+    }
+    .padding(.horizontal, 14)
+    .frame(width: 172, height: 38)
+    .background(.regularMaterial, in: Capsule())
+    .overlay(Capsule().strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5))
+    .shadow(color: .black.opacity(0.18), radius: 7, y: 3)
+  }
+
+  static func format(seconds: Double) -> String {
+    let total = max(0, Int(seconds))
+    let h = total / 3600
+    let m = (total % 3600) / 60
+    let s = total % 60
+    if h > 0 {
+      return String(format: "%d:%02d:%02d", h, m, s)
+    }
+    return String(format: "%d:%02d", m, s)
+  }
+}

--- a/Dayflow/Dayflow/Views/UI/Settings/SettingsOtherTabView.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/SettingsOtherTabView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct SettingsOtherTabView: View {
   @ObservedObject var viewModel: OtherSettingsViewModel
   @ObservedObject var launchAtLoginManager: LaunchAtLoginManager
+  @ObservedObject private var miniTimer = MiniTimerWindowController.shared
   @FocusState private var isOutputLanguageFocused: Bool
 
   var body: some View {
@@ -62,10 +63,23 @@ struct SettingsOtherTabView: View {
         SettingsRow(
           label: "Save all timelapses to disk",
           subtitle:
-            "New and reprocessed timeline cards will pre-generate timelapse videos and store them on disk instead of building them on demand. Uses more storage and background processing.",
-          showsDivider: false
+            "New and reprocessed timeline cards will pre-generate timelapse videos and store them on disk instead of building them on demand. Uses more storage and background processing."
         ) {
           SettingsToggle(isOn: $viewModel.saveAllTimelapsesToDisk)
+        }
+
+        SettingsRow(
+          label: "Show focus timer",
+          subtitle:
+            "A small floating pill that counts up today's focused time live. Drag it anywhere; toggle it from the menu bar too.",
+          showsDivider: false
+        ) {
+          SettingsToggle(
+            isOn: Binding(
+              get: { miniTimer.isVisible },
+              set: { miniTimer.setVisible($0) }
+            )
+          )
         }
       }
     }


### PR DESCRIPTION
## What

Adds an optional, always-on-top **focus Mini Timer** — a small floating pill that shows today's focused time and counts up live.

## How it works

- **Focused time** is aggregated from analyzed timeline cards (everything that isn't `Idle` or `Distraction`), using the epoch `start_ts`/`end_ts` columns rather than the display text.
- Because analysis runs in ~15-min batches, the timer is **live-optimistic**: it takes the processed total and extends the most recent focused segment forward to *now*, but only while you're actively recording — not paused, and not idle (a non-latching `CGEventSource` system-idle check). When the next batch lands, the processed total absorbs the gap, so the number stays smooth. The forward extension is capped so a stalled pipeline can't run it away.

## UX

- Non-activating `NSPanel` at floating level, joins all Spaces (incl. fullscreen), draggable, remembers its position. **Off by default.**
- Toggle from the **menu bar** (Show/Hide Focus Timer) or **Settings → Other**.

## Files

- New: `ProductivityStats`, `ProductivityPreferences`, `MiniTimerWindowController`, `MiniTimerView`, and a small epoch-based `fetchTimelineActivity` query on `StorageManager`.
- Touched: `AppDelegate` (startup), `StatusMenuView` (menu toggle), `SettingsOtherTabView` (settings toggle).

Builds against `main`. The shared `ProductivityStats`/`fetchTimelineActivity` helper is intentionally small so a companion distraction-nudges change can reuse it.