### PR TITLE
Fixes #295

### DIFF
--- a/Dayflow/Dayflow/Views/UI/MainView/Layout.swift
+++ b/Dayflow/Dayflow/Views/UI/MainView/Layout.swift
@@ -121,9 +121,10 @@ extension MainView {
         onOpenSettings: { handleTimelineFailureToastOpenSettings(payload) },
         onDismiss: { handleTimelineFailureToastDismiss(payload) }
       )
+      .environment(\.layoutDirection, .leftToRight)
       .padding(.trailing, 24)
       .padding(.bottom, 24)
-      .transition(.move(edge: .trailing).combined(with: .opacity))
+      .transition(toastOverlayTransition)
     }
   }
 
@@ -134,10 +135,21 @@ extension MainView {
         onOpenSettings: handleScreenRecordingPermissionNoticeOpenSettings,
         onDismiss: handleScreenRecordingPermissionNoticeDismiss
       )
+      .environment(\.layoutDirection, .leftToRight)
       .padding(.trailing, 24)
       .padding(.bottom, 24)
-      .transition(.move(edge: .trailing).combined(with: .opacity))
+      .transition(toastOverlayTransition)
     }
+  }
+
+  private var toastOverlayTransition: AnyTransition {
+    // Avoid `.move(edge:)` here. On macOS, edge transitions on bottom-trailing
+    // overlays can briefly reuse a flipped layer snapshot while other overlays
+    // are animating, which presents the toast text mirrored/upside down.
+    .asymmetric(
+      insertion: .opacity.combined(with: .offset(x: 18)),
+      removal: .opacity.combined(with: .offset(x: 12))
+    )
   }
 
   private func performMainLayoutOnAppear() {
@@ -483,6 +495,7 @@ private struct TimelineFailureToastView: View {
       RoundedRectangle(cornerRadius: 12)
         .stroke(Color(hex: "F3D9C2"), lineWidth: 1)
     )
+    .compositingGroup()
     .shadow(color: Color.black.opacity(0.12), radius: 12, x: 0, y: 6)
   }
 }
@@ -550,6 +563,7 @@ private struct ScreenRecordingPermissionNoticeView: View {
       RoundedRectangle(cornerRadius: 12)
         .stroke(Color(hex: "F3D9C2"), lineWidth: 1)
     )
+    .compositingGroup()
     .shadow(color: Color.black.opacity(0.12), radius: 12, x: 0, y: 6)
   }
 }


### PR DESCRIPTION
Replaces the bottom-trailing toast `.move(edge: .trailing)` transition with an opacity + offset transition, forces left-to-right layout for the toast, and isolates the toast render layer to prevent intermittent mirrored/upside-down rendering on macOS.