### PR TITLE
feat(local): concurrent frame transcription for local models

### DIFF
--- a/Dayflow/Dayflow/Core/AI/OllamaProvider+Transcription.swift
+++ b/Dayflow/Dayflow/Core/AI/OllamaProvider+Transcription.swift
@@ -65,6 +65,15 @@ extension OllamaProvider {
     }
   }
 
+  private func describeFrameResult(_ frame: FrameData, batchId: Int64?) async -> (
+    TimeInterval, String
+  )? {
+    guard let description = await getSimpleFrameDescription(frame, batchId: batchId) else {
+      return nil
+    }
+    return (frame.timestamp, description)
+  }
+
   private func parseVideoTimestamp(_ timestamp: String) -> Int {
     let components = timestamp.components(separatedBy: ":")
 
@@ -474,19 +483,46 @@ extension OllamaProvider {
     let lastTs = sampledScreenshots.last!.capturedAt
     let durationSeconds = TimeInterval(lastTs - firstTs)
 
-    // Describe each screenshot
-    var frameDescriptions: [(timestamp: TimeInterval, description: String)] = []
-
+    // Describe each screenshot. Loading is cheap CPU work done sequentially; the
+    // describe calls are the slow, independent part, so run up to `maxConcurrency`
+    // of them in flight against the local server. Completion order is
+    // non-deterministic, so results are re-sorted by timestamp afterward.
+    var frames: [FrameData] = []
     for screenshot in sampledScreenshots {
       guard let frameData = loadScreenshotAsFrameData(screenshot, relativeTo: firstTs) else {
         print("[OLLAMA] ⚠️ Failed to load screenshot: \(screenshot.filePath)")
         continue
       }
-
-      if let description = await getSimpleFrameDescription(frameData, batchId: batchId) {
-        frameDescriptions.append((timestamp: frameData.timestamp, description: description))
-      }
+      frames.append(frameData)
     }
+
+    let concurrency = max(1, maxConcurrency)
+    var frameDescriptions = await withTaskGroup(
+      of: (TimeInterval, String)?.self,
+      returning: [(timestamp: TimeInterval, description: String)].self
+    ) { group in
+      var cursor = 0
+      while cursor < frames.count && cursor < concurrency {
+        let frameData = frames[cursor]
+        group.addTask { await self.describeFrameResult(frameData, batchId: batchId) }
+        cursor += 1
+      }
+
+      var collected: [(timestamp: TimeInterval, description: String)] = []
+      while let result = await group.next() {
+        if let (timestamp, description) = result {
+          collected.append((timestamp: timestamp, description: description))
+        }
+        if cursor < frames.count {
+          let frameData = frames[cursor]
+          group.addTask { await self.describeFrameResult(frameData, batchId: batchId) }
+          cursor += 1
+        }
+      }
+      return collected
+    }
+
+    frameDescriptions.sort { $0.timestamp < $1.timestamp }
 
     guard !frameDescriptions.isEmpty else {
       throw NSError(

--- a/Dayflow/Dayflow/Core/AI/OllamaProvider.swift
+++ b/Dayflow/Dayflow/Core/AI/OllamaProvider.swift
@@ -6,7 +6,7 @@
 import AppKit
 import Foundation
 
-final class OllamaProvider {
+final class OllamaProvider: @unchecked Sendable {
   let endpoint: String
   let screenshotInterval: TimeInterval = 10  // seconds between screenshots
   // Read persisted local settings
@@ -34,6 +34,16 @@ final class OllamaProvider {
   // Get the actual local engine type for analytics tracking
   var localEngine: String {
     UserDefaults.standard.string(forKey: "llmLocalEngine") ?? "ollama"
+  }
+
+  // How many describe_frame requests to run against the local server at once.
+  // The server caps this itself (LM Studio "Max Concurrent Predictions", Ollama
+  // OLLAMA_NUM_PARALLEL) and doesn't expose the limit over HTTP, so keep this ≤
+  // that value. Default 1 (sequential). Override via
+  // `defaults write teleportlabs.com.Dayflow llmLocalMaxConcurrency <n>`.
+  var maxConcurrency: Int {
+    let configured = UserDefaults.standard.integer(forKey: "llmLocalMaxConcurrency")
+    return configured > 0 ? min(configured, 16) : 1
   }
 
   init(endpoint: String = "http://localhost:1234") {

--- a/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
@@ -49,6 +49,12 @@ final class ProvidersSettingsViewModel: ObservableObject {
       persistLocalAPIKey(localAPIKey)
     }
   }
+  @Published var localMaxConcurrency: Int {
+    didSet {
+      guard oldValue != localMaxConcurrency else { return }
+      UserDefaults.standard.set(localMaxConcurrency, forKey: "llmLocalMaxConcurrency")
+    }
+  }
   @Published var showLocalModelUpgradeBanner = false
   @Published var isShowingLocalModelUpgradeSheet = false
   @Published var upgradeStatusMessage: String?
@@ -136,6 +142,8 @@ final class ProvidersSettingsViewModel: ObservableObject {
     }
 
     localAPIKey = UserDefaults.standard.string(forKey: "llmLocalAPIKey") ?? ""
+    let storedConcurrency = UserDefaults.standard.integer(forKey: "llmLocalMaxConcurrency")
+    localMaxConcurrency = storedConcurrency > 0 ? min(storedConcurrency, 16) : 1
     if let raw = UserDefaults.standard.string(forKey: "chatCLIPreferredTool") {
       preferredCLITool = CLITool(rawValue: raw)
     } else {
@@ -189,6 +197,8 @@ final class ProvidersSettingsViewModel: ObservableObject {
     localBaseURL = UserDefaults.standard.string(forKey: "llmLocalBaseURL") ?? localBaseURL
     localModelId = UserDefaults.standard.string(forKey: "llmLocalModelId") ?? localModelId
     localAPIKey = UserDefaults.standard.string(forKey: "llmLocalAPIKey") ?? localAPIKey
+    let storedConcurrency = UserDefaults.standard.integer(forKey: "llmLocalMaxConcurrency")
+    localMaxConcurrency = storedConcurrency > 0 ? min(storedConcurrency, 16) : 1
     let raw = UserDefaults.standard.string(forKey: "llmLocalEngine") ?? localEngine.rawValue
     localEngine = LocalEngine(rawValue: raw) ?? localEngine
     LocalModelPreferences.syncPreset(for: localEngine, modelId: localModelId)

--- a/Dayflow/Dayflow/Views/UI/Settings/SettingsProvidersTabView.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/SettingsProvidersTabView.swift
@@ -97,6 +97,14 @@ struct SettingsProvidersTabView: View {
           text: viewModel.localModelId.isEmpty ? "Not configured" : viewModel.localModelId)
       }
       SettingsRow(label: "Endpoint") { SettingsMetadata(text: viewModel.localBaseURL) }
+      SettingsRow(label: "Max concurrent requests") {
+        HStack(spacing: 8) {
+          SettingsMetadata(text: "\(viewModel.localMaxConcurrency)")
+          Stepper("", value: $viewModel.localMaxConcurrency, in: 1...16)
+            .labelsHidden()
+            .fixedSize()
+        }
+      }
       let hasKey = !viewModel.localAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
       SettingsRow(label: "API key", showsDivider: false) {
         SettingsMetadata(text: hasKey ? "Stored in UserDefaults" : "Not set")


### PR DESCRIPTION
Local batch processing describes screenshots **one at a time**; roughly 15 sequential `describe_frame` vision calls per batch, which dominates transcription time. This PR makes that concurrency **configurable** so users whose local server can handle parallel requests can run several frame descriptions in flight and cut transcription time.

Opt-in: the default is `1` (today's sequential behavior), so nothing changes unless the user raises it.

## Changes

- **New setting `llmLocalMaxConcurrency`** (`Int`, default `1`, clamped to `1…16`), read by `OllamaProvider.maxConcurrency`.
- **Parallel frame description**: `OllamaProvider.transcribeScreenshots` now runs `describe_frame` calls through a bounded `withTaskGroup` (up to `maxConcurrency` in flight), re-sorting results by timestamp. The dependent `segment → summary → title` chain is untouched (it can't be parallelized).
- **Settings UI**: a "Max concurrent requests" stepper (1–16) in **Settings → Providers**, shown only for the local provider, wired through `ProvidersSettingsViewModel`.
- `OllamaProvider` marked `@unchecked Sendable` so the task-group closures can capture it (effectively immutable; `let endpoint` + `UserDefaults` reads), matching the existing convention (`StorageManager`, `ScreenRecorder`).

## Why manual setting

The local server's concurrency limit isn't exposed over HTTP: LM Studio reports model state/quant/context via `/api/v0/models` but **not** "Max Concurrent Predictions", and Ollama's parallelism is the `OLLAMA_NUM_PARALLEL` env var. So Dayflow can't detect it; the user sets it to match their server (keep it ≤ the server's own limit; going higher just queues server-side).

## Notes / expectations

- Speedup is GPU-bound. N concurrent is **not** N× throughput; on a healthy setup transcription typically drops ~1.5–2.5×.
- Only the independent `describe_frame` calls are parallelized.

## Risk / scope

- Opt-in; no behavior change unless the setting is raised above 1.
- Contained to the local-provider transcription path + its settings UI.