### PR TITLE
feat(local): configurable request timeout (default 180s)

### DIFF
--- a/Dayflow/Dayflow/Core/AI/OllamaProvider+Networking.swift
+++ b/Dayflow/Dayflow/Core/AI/OllamaProvider+Networking.swift
@@ -66,7 +66,7 @@ extension OllamaProvider {
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         applyAuthorizationHeader(to: &urlRequest)
         urlRequest.httpBody = try JSONEncoder().encode(request)
-        urlRequest.timeoutInterval = 60.0  // 60-second timeout
+        urlRequest.timeoutInterval = requestTimeout
 
         let start = Date()
         apiStart = start

--- a/Dayflow/Dayflow/Core/AI/OllamaProvider.swift
+++ b/Dayflow/Dayflow/Core/AI/OllamaProvider.swift
@@ -36,6 +36,13 @@ final class OllamaProvider {
     UserDefaults.standard.string(forKey: "llmLocalEngine") ?? "ollama"
   }
 
+  // Per-request idle timeout. Default to 180s; override via
+  // `defaults write teleportlabs.com.Dayflow llmLocalRequestTimeout <seconds>`.
+  var requestTimeout: TimeInterval {
+    let configured = UserDefaults.standard.double(forKey: "llmLocalRequestTimeout")
+    return configured > 0 ? configured : 180
+  }
+
   init(endpoint: String = "http://localhost:1234") {
     self.endpoint = endpoint
   }


### PR DESCRIPTION
Local calls use hardcoded 60s `URLRequest.timeoutInterval`. Because requests are non-streaming, that timer behaves as an **idle** timeout that must cover the model's *entire* generation with no keep-alive bytes to reset it.
60s can easily be reached on slower hardware especially on cold load of model, causing failures that become "Processing failed" cards.

## Changes

Makes the timeout **configurable** via a new `llmLocalRequestTimeout` setting with a more generous default of **180s**.

- New `OllamaProvider.requestTimeout`, reads `llmLocalRequestTimeout`, default `180`.
- `OllamaProvider+Networking.callChatAPI` uses it instead of the hardcoded `60.0`.

## Risk / scope

- Local-provider only: one computed property + one call-site change.