### PR TITLE
fix: scope reprocess/retries to specific batch

### DIFF
--- a/Dayflow/Dayflow/Core/AI/LLMService.swift
+++ b/Dayflow/Dayflow/Core/AI/LLMService.swift
@@ -21,7 +21,7 @@ enum LLMProcessingStep: Sendable, Equatable {
 
 protocol LLMServicing {
   func processBatch(
-    _ batchId: Int64, progressHandler: ((LLMProcessingStep) -> Void)?,
+    _ batchId: Int64, isReprocess: Bool, progressHandler: ((LLMProcessingStep) -> Void)?,
     completion: @escaping (Result<ProcessedBatchResult, Error>) -> Void)
   func generateText(prompt: String) async throws -> String
   func generateTextStreaming(prompt: String) -> AsyncThrowingStream<String, Error>
@@ -551,7 +551,8 @@ final class LLMService: LLMServicing {
 
   // Keep the existing processBatch implementation for backward compatibility
   func processBatch(
-    _ batchId: Int64, progressHandler: ((LLMProcessingStep) -> Void)? = nil,
+    _ batchId: Int64, isReprocess: Bool = false,
+    progressHandler: ((LLMProcessingStep) -> Void)? = nil,
     completion: @escaping (Result<ProcessedBatchResult, Error>) -> Void
   ) {
     Task {
@@ -689,7 +690,10 @@ final class LLMService: LLMServicing {
 
         // Calculate card-generation lookback window.
         let currentTime = Date(timeIntervalSince1970: TimeInterval(batchEndTs))
-        let windowStartTime = currentTime.addingTimeInterval(-batchingConfig.cardLookbackDuration)
+        let windowStartTime =
+          isReprocess
+          ? batchStartDate
+          : currentTime.addingTimeInterval(-batchingConfig.cardLookbackDuration)
 
         // Fetch observations from the recent batching window (instead of just current batch).
         let recentObservations = StorageManager.shared.fetchObservationsByTimeRange(
@@ -703,25 +707,51 @@ final class LLMService: LLMServicing {
           print("       observation: \(obs.observation)")
         }
 
-        // Fetch existing timeline cards that overlap with the recent batching window.
-        let existingTimelineCards = StorageManager.shared.fetchTimelineCardsByTimeRange(
-          from: windowStartTime,
-          to: currentTime
-        )
+        // Merge context.
+        // Live: uses  whole lookback window
+        // Reprocess: uses only immediately-preceding real card
+        let reprocessMergeAnchor: TimelineCardWithTimestamps? =
+          isReprocess
+          ? StorageManager.shared.fetchLastTimelineCard(endingBefore: batchStartDate)
+            .flatMap { $0.title == "Processing failed" ? nil : $0 }
+          : nil
 
-        // Convert TimelineCards to ActivityCardData for context
-        let existingActivityCards = existingTimelineCards.map { card in
-          ActivityCardData(
-            startTime: card.startTimestamp,
-            endTime: card.endTimestamp,
-            category: card.category,
-            subcategory: card.subcategory,
-            title: card.title,
-            summary: card.summary,
-            detailedSummary: card.detailedSummary,
-            distractions: card.distractions,
-            appSites: card.appSites
+        let existingActivityCards: [ActivityCardData]
+        if isReprocess {
+          existingActivityCards =
+            reprocessMergeAnchor.map { anchor in
+              [
+                ActivityCardData(
+                  startTime: anchor.startTimestamp,
+                  endTime: anchor.endTimestamp,
+                  category: anchor.category,
+                  subcategory: anchor.subcategory,
+                  title: anchor.title,
+                  summary: anchor.summary,
+                  detailedSummary: anchor.detailedSummary,
+                  distractions: anchor.distractions,
+                  appSites: nil
+                )
+              ]
+            } ?? []
+        } else {
+          let existingTimelineCards = StorageManager.shared.fetchTimelineCardsByTimeRange(
+            from: windowStartTime,
+            to: currentTime
           )
+          existingActivityCards = existingTimelineCards.map { card in
+            ActivityCardData(
+              startTime: card.startTimestamp,
+              endTime: card.endTimestamp,
+              category: card.category,
+              subcategory: card.subcategory,
+              title: card.title,
+              summary: card.summary,
+              detailedSummary: card.detailedSummary,
+              distractions: card.distractions,
+              appSites: card.appSites
+            )
+          }
         }
 
         // Prepare context for activity generation
@@ -765,12 +795,30 @@ final class LLMService: LLMServicing {
         let isBackupGenerated = usedProviderBackup || usedGemmaForCardGeneration
         // Note: card generation log is not persisted per-batch yet
 
+        // Scope the write
+        let writeFromTime: Date
+        let cardsToWrite: [ActivityCardData]
+        if isReprocess {
+          let didMerge =
+            !existingActivityCards.isEmpty && cards.count == existingActivityCards.count
+          if didMerge, let anchor = reprocessMergeAnchor {
+            writeFromTime = Date(timeIntervalSince1970: TimeInterval(anchor.startTs))
+            cardsToWrite = cards
+          } else {
+            writeFromTime = batchStartDate
+            cardsToWrite = Array(cards.dropFirst(existingActivityCards.count))
+          }
+        } else {
+          writeFromTime = windowStartTime
+          cardsToWrite = cards
+        }
+
         // Replace old cards with new ones in the time range
         let (insertedCardIds, deletedVideoPaths) = StorageManager.shared
           .replaceTimelineCardsInRange(
-            from: windowStartTime,
+            from: writeFromTime,
             to: currentTime,
-            with: cards.map { card in
+            with: cardsToWrite.map { card in
               TimelineCardShell(
                 startTimestamp: card.startTime,
                 endTimestamp: card.endTime,

--- a/Dayflow/Dayflow/Core/Analysis/AnalysisManager.swift
+++ b/Dayflow/Dayflow/Core/Analysis/AnalysisManager.swift
@@ -278,7 +278,7 @@ final class AnalysisManager: AnalysisManaging {
           )
         }
 
-        self.queueLLMRequest(batchId: batchId)
+        self.queueLLMRequest(batchId: batchId, isReprocess: true)
 
         // Wait for batch to complete (check status periodically)
         var isCompleted = false
@@ -371,6 +371,7 @@ final class AnalysisManager: AnalysisManaging {
 
       self.queueLLMRequest(
         batchId: batchId,
+        isReprocess: true,
         progressHandler: stepHandler,
         completion: { result in
           DispatchQueue.main.async {
@@ -400,6 +401,7 @@ final class AnalysisManager: AnalysisManaging {
 
   private func queueLLMRequest(
     batchId: Int64,
+    isReprocess: Bool = false,
     progressHandler: ((LLMProcessingStep) -> Void)? = nil,
     completion: ((Result<Void, Error>) -> Void)? = nil
   ) {
@@ -473,7 +475,7 @@ final class AnalysisManager: AnalysisManaging {
 
     updateBatchStatus(batchId: batchId, status: "processing")
 
-    llmService.processBatch(batchId, progressHandler: progressHandler) {
+    llmService.processBatch(batchId, isReprocess: isReprocess, progressHandler: progressHandler) {
       [weak self] (result: Result<ProcessedBatchResult, Error>) in
       guard let self else { return }
 


### PR DESCRIPTION
Retrying/reprocessing a batch reused the **live** card-generation path, which regenerates cards over a 45-minute sliding window and replaces that whole window under the reprocessed batch's id. 

For a live, forward-moving batch that's fine. 
For a retry of an *old* batch it isn't: it sweeps in neighbouring batches' cards (including their "Processing failed" cards), re-tags them to the retried batch, and rewrites them; so **stale error cards get duplicated on every retry**, compounding into large numbers of identical "Processing failed" cards.

This scopes reprocessing to the batch's own range (so it can't carry forward or duplicate neighbours), while still merging the regenerated card with the immediately-preceding real card so retried runs collapse into merged cards, like live does.

## Changes

- `processBatch` gains an `isReprocess` flag (default `false` = current live behavior).
- **When reprocessing:**
  - The card-generation window is scoped to the batch's own range (`windowStartTime = batchStartDate`) instead of the 45-min lookback, and the write only touches that range; mirroring the failure path, which is already batch-scoped.
  - Merge context is just the **immediately-preceding real card** (via `fetchLastTimelineCard(endingBefore:)`, skipping "Processing failed" cards). `generateActivityCards` applies the same gap/duration/LLM merge rules as live; if it merges, the write extends to absorb that one neighbour, otherwise the untouched neighbour is dropped from the write.
- `AnalysisManager.reprocessBatch` / `reprocessSpecificBatches` pass `isReprocess: true`. Live processing and `reprocessDay` keep the default (`reprocessDay` already rebuilds a day from empty, so its merge is correct).

## Risk / scope

- `isReprocess` defaults to `false`, so live processing is unchanged; only the reprocess entry points change.