### PR TITLE
fix(recording): restore correct display selection after screen unlock

### DIFF
--- a/Dayflow/Dayflow/Core/Recording/ScreenRecorder.swift
+++ b/Dayflow/Dayflow/Core/Recording/ScreenRecorder.swift
@@ -233,7 +233,7 @@ final class ScreenRecorder: NSObject, @unchecked Sendable {
         false, onScreenWindowsOnly: true)
       cachedContent = content
 
-      // 2. Choose display: prefer requested → active → first
+      // 2. Choose display: prefer requested → active. Defer if preferred is missing from the snapshot.
       let displaysByID: [CGDirectDisplayID: SCDisplay] = Dictionary(
         uniqueKeysWithValues: content.displays.map { ($0.displayID, $0) }
       )
@@ -242,20 +242,30 @@ final class ScreenRecorder: NSObject, @unchecked Sendable {
       }
       let preferredID = requestedDisplayID ?? trackerID
 
-      let display: SCDisplay
-      if let pid = preferredID, let scd = displaysByID[pid] {
-        display = scd
+      let display: SCDisplay?
+      if let pid = preferredID {
+        display = displaysByID[pid]
+        if display == nil {
+          requestedDisplayID = pid
+          dbg("setupCapture: preferred display \(pid) not in snapshot (count=\(content.displays.count)); deferring")
+        } else {
+          requestedDisplayID = nil
+        }
       } else if let first = content.displays.first {
         display = first
+        requestedDisplayID = nil
       } else {
         throw ScreenRecorderError.noDisplay
       }
 
       cachedDisplay = display
-      currentDisplayID = display.displayID
-      requestedDisplayID = nil
+      currentDisplayID = display?.displayID
 
-      dbg("Setup complete - display \(display.displayID) (\(display.width)x\(display.height))")
+      if let d = display {
+        dbg("Setup complete - display \(d.displayID) (\(d.width)x\(d.height))")
+      } else {
+        dbg("Setup complete - awaiting display availability")
+      }
 
       // 3. Start capture timer
       q.async { [weak self] in
@@ -470,17 +480,19 @@ final class ScreenRecorder: NSObject, @unchecked Sendable {
         false, onScreenWindowsOnly: true)
       cachedContent = content
 
-      // Prefer requested display (from active display tracking) over current
+      // Prefer requested display over current; hold if missing from snapshot.
       let targetID = requestedDisplayID ?? currentDisplayID
 
-      if let id = targetID,
-        let display = content.displays.first(where: { $0.displayID == id })
-      {
-        cachedDisplay = display
-        currentDisplayID = id
-        if requestedDisplayID == id { requestedDisplayID = nil }
-        dbg("Switched to display \(id)")
-      } else if let first = content.displays.first {
+      if let id = targetID {
+        if let display = content.displays.first(where: { $0.displayID == id }) {
+          cachedDisplay = display
+          currentDisplayID = id
+          if requestedDisplayID == id { requestedDisplayID = nil }
+          dbg("Switched to display \(id)")
+        } else {
+          dbg("refreshDisplay: target \(id) not in snapshot (count=\(content.displays.count)); keeping current")
+        }
+      } else if let first = content.displays.first, cachedDisplay == nil {
         cachedDisplay = first
         currentDisplayID = first.displayID
       }
@@ -546,7 +558,7 @@ final class ScreenRecorder: NSObject, @unchecked Sendable {
       return
     }
 
-    guard currentDisplayID != nil, state == .capturing else {
+    guard state == .capturing else {
       dbg("Active display changed while not capturing – will switch on next start")
       return
     }
@@ -563,6 +575,18 @@ final class ScreenRecorder: NSObject, @unchecked Sendable {
   private func registerForSleepAndLock() {
     let nc = NSWorkspace.shared.notificationCenter
     let dnc = DistributedNotificationCenter.default()
+
+    // Screen configuration changed — recover any deferred display selection.
+    NotificationCenter.default.addObserver(
+      forName: NSApplication.didChangeScreenParametersNotification,
+      object: nil, queue: nil
+    ) { [weak self] _ in
+      self?.q.async { [weak self] in
+        guard let self, self.state == .capturing else { return }
+        dbg("didChangeScreenParameters – refreshing display selection")
+        Task { await self.refreshDisplay() }
+      }
+    }
 
     // System will sleep
     nc.addObserver(


### PR DESCRIPTION
## Summary

Fixes #277.

On dual-monitor Macs, when an external display sleeps during screen lock, `SCShareableContent.displays` transiently reports only the built-in display for a couple of seconds after unlock. `ScreenRecorder.setupCapture` runs inside that window (via `resumeRecording(after: 0.5)`) and its fallback to `content.displays.first` selects the built-in, even though the tracker's `activeDisplayID` still points at the external. Once `cachedDisplay = built-in`, the tracker's `.removeDuplicates()` swallows any republish of the same id, so `handleActiveDisplayChange` and `refreshDisplay` never re-run — capture stays on the wrong display until the cursor crosses screens for a genuine tracker id change (in the affected user's real workflow, that meant 22 minutes of misclassified capture).

## Fix

Three linked changes in `ScreenRecorder.swift`:

1. **`setupCapture`**: when a preferred display id exists but isn't in the current snapshot, don't fall back to `content.displays.first`. Persist the wanted id as `requestedDisplayID` and leave `cachedDisplay = nil` (`captureScreenshot` already handles nil).
2. **`refreshDisplay`**: same principle — if the target id isn't in the snapshot, keep `cachedDisplay` untouched rather than picking a different display.
3. **New observer on `NSApplication.didChangeScreenParametersNotification`** in `registerForSleepAndLock()` calls `refreshDisplay()` when screens change. This is the recovery path: when the external monitor finishes waking up, `refreshDisplay` finds the persisted `requestedDisplayID` in the fresh snapshot and restores capture to it.

Also removes `currentDisplayID != nil` from `handleActiveDisplayChange`'s guard, since after (1) `.capturing` no longer implies a resolved display.

## Test plan

- [x] Builds (Debug, macOS arm64)
- [ ] Maintainer manual repro: dual-monitor setup, work on external, lock (Ctrl+Cmd+Q), wait 60 s so the external sleeps, unlock, keep working. Resulting timeline card should describe external-monitor content; without the fix it labels as whatever was on the built-in.
