### PR TITLE
fix(project): wire DayflowUITests target to its own source folder

### DIFF
--- a/Dayflow/Dayflow.xcodeproj/project.pbxproj
+++ b/Dayflow/Dayflow.xcodeproj/project.pbxproj
@@ -49,6 +49,11 @@
 			path = DayflowTests;
 			sourceTree = "<group>";
 		};
+		C4C1D2FF2DB56806007D5A56 /* DayflowUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = DayflowUITests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -86,6 +91,7 @@
 			children = (
 				C4C1D2A32DB56805007D5A55 /* Dayflow */,
 				FEFD599FBA059B170B03FA5E /* DayflowTests */,
+				C4C1D2FF2DB56806007D5A56 /* DayflowUITests */,
 				C4DF00012EFB100000000001 /* Config/Dayflow.xcconfig */,
 				C4C1D2A22DB56805007D5A55 /* Products */,
 			);
@@ -166,6 +172,9 @@
 			);
 			dependencies = (
 				C4C1D2BE2DB56806007D5A55 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				C4C1D2FF2DB56806007D5A56 /* DayflowUITests */,
 			);
 			name = DayflowUITests;
 			packageProductDependencies = (


### PR DESCRIPTION
## what

`DayflowUITests` never actually built or ran. Every attempt (`xcodebuild ... -only-testing:DayflowUITests test`) failed with:

```
Failed to load the test bundle. (Underlying Error: The bundle "DayflowUITests"
couldn't be loaded because its executable couldn't be located.)
```

## root cause

`DayflowUITests` had **no `PBXFileSystemSynchronizedRootGroup` entry at all** — unlike its siblings `Dayflow` and `DayflowTests`, which each have one. Xcode 16+'s synced-group mechanism is how a target's source folder gets auto-discovered without listing every file explicitly; without that entry, Xcode had literally no path to `Dayflow/DayflowUITests/`. Build logs confirmed it: an `empty-DayflowUITests.plist` gets generated, and the `.xctest` bundle ships with zero compiled executable.

## fix

Mirrors the existing `DayflowTests` wiring exactly: a new synced-group entry pointing at the `DayflowUITests` folder, referenced from the target's `fileSystemSynchronizedGroups` and the top-level group's `children`. 3 lines total, same shape as the working `DayflowTests` entry.

## verification

```
# before
$ xcodebuild -scheme Dayflow -only-testing:DayflowUITests test
Failed to load the test bundle... couldn't be located
** TEST FAILED **

# after
$ file .../DayflowUITests.xctest/Contents/MacOS/DayflowUITests
Mach-O 64-bit bundle arm64

$ xcodebuild -scheme Dayflow -only-testing:DayflowUITests test
** TEST SUCCEEDED **
Test case 'DayflowUITests.testExample()' passed (4.704 seconds)
Test case 'DayflowUITests.testLaunchPerformance()' passed (16.034 seconds)
Test case 'DayflowUITestsLaunchTests.testLaunch()' passed (3.554 seconds)
Test case 'DayflowUITestsLaunchTests.testLaunch()' passed (3.254 seconds)
```

the launch tests drive a real `XCUIApplication` launch — not stubs. re-ran `-only-testing:DayflowTests` afterward to confirm no regression: 6/6 still pass.

---

---

## Follow-up hardening pass (2026-07-08)

Re-verified end-to-end: `xcodebuild ... -only-testing:DayflowUITests test` -> **TEST SUCCEEDED, 4/4 tests pass** (testExample, testLaunchPerformance, testLaunch x2 -- all driving a real XCUIApplication launch). Also confirmed the structural fix independently: build-for-testing produces a real Mach-O executable at `DayflowUITests.xctest/Contents/MacOS/DayflowUITests` (pre-fix, that bundle had no executable at all).

(One re-run mid-session hit a transient "Timed out while enabling automation mode" -- isolated to UI-automation initialization under accumulated load from repeated test invocations, not a code defect: plain unit tests kept passing throughout, and re-running with a normal automation-timeout allowance passed cleanly 4/4. Not app-instance-related -- the tests pass with or without a production app running.)
