### PR TITLE
Add OpenRouter provider

### DIFF
--- a/Dayflow/Dayflow/Core/AI/LLMService.swift
+++ b/Dayflow/Dayflow/Core/AI/LLMService.swift
@@ -110,6 +110,10 @@ final class LLMService: LLMServicing {
     OllamaProvider(endpoint: endpoint)
   }
 
+  private func makeOpenRouterProvider() -> OpenRouterProvider {
+    OpenRouterProvider()
+  }
+
   private func makeChatCLIProvider(preferredToolOverride: ChatCLITool? = nil) -> ChatCLIProvider {
     let tool: ChatCLITool
     if let preferredToolOverride {
@@ -228,6 +232,14 @@ final class LLMService: LLMServicing {
       )
     case .chatGPTClaude:
       let provider = makeChatCLIProvider(preferredToolOverride: chatToolOverride)
+      return (
+        actions: BatchProviderActions(
+          transcribeScreenshots: provider.transcribeScreenshots,
+          generateActivityCards: provider.generateActivityCards
+        ), fallbackState: nil
+      )
+    case .openRouter:
+      let provider = makeOpenRouterProvider()
       return (
         actions: BatchProviderActions(
           transcribeScreenshots: provider.transcribeScreenshots,
@@ -514,6 +526,14 @@ final class LLMService: LLMServicing {
       )
     case .chatGPTClaude:
       let provider = makeChatCLIProvider()
+      return TextProviderActions(
+        generateText: { prompt in
+          try await provider.generateText(prompt: prompt)
+        },
+        generateTextStreaming: provider.generateTextStreaming
+      )
+    case .openRouter:
+      let provider = makeOpenRouterProvider()
       return TextProviderActions(
         generateText: { prompt in
           try await provider.generateText(prompt: prompt)
@@ -1119,6 +1139,9 @@ final class LLMService: LLMServicing {
       let tool: ChatCLITool = request.provider == .claude ? .claude : .codex
       let chatCLI = makeChatCLIProvider(preferredToolOverride: tool)
       return chatCLI.generateChatStreaming(prompt: request.prompt, sessionId: request.sessionId)
+    case .openRouter:
+      let provider = makeOpenRouterProvider()
+      return provider.generateTextStreaming(prompt: request.prompt)
     }
   }
 }

--- a/Dayflow/Dayflow/Core/AI/LLMTypes.swift
+++ b/Dayflow/Dayflow/Core/AI/LLMTypes.swift
@@ -16,6 +16,7 @@ enum DashboardChatProvider: String, Codable, CaseIterable {
   case gemini
   case codex
   case claude
+  case openRouter = "openrouter"
 
   static func fromStoredValue(_ value: String?) -> DashboardChatProvider {
     guard let value else { return .gemini }
@@ -24,7 +25,7 @@ enum DashboardChatProvider: String, Codable, CaseIterable {
 
   var chatCLITool: ChatCLITool? {
     switch self {
-    case .gemini:
+    case .gemini, .openRouter:
       return nil
     case .codex:
       return .codex
@@ -41,6 +42,8 @@ enum DashboardChatProvider: String, Codable, CaseIterable {
     switch self {
     case .gemini:
       return "gemini_function_calling"
+    case .openRouter:
+      return "openrouter_api"
     case .codex, .claude:
       return "chat_cli"
     }
@@ -96,6 +99,7 @@ enum LLMProviderType: Codable {
   case dayflowBackend(endpoint: String = "")
   case ollamaLocal(endpoint: String = "http://localhost:11434")
   case chatGPTClaude
+  case openRouter(modelId: String = "deepseek/deepseek-v4-flash")
 
   private static let providerDefaultsKey = "llmProviderType"
   private static let selectedProviderDefaultsKey = "selectedLLMProvider"
@@ -134,6 +138,8 @@ enum LLMProviderType: Codable {
       return "ollama"
     case .chatGPTClaude:
       return "chatgpt_claude"
+    case .openRouter:
+      return "openrouter"
     }
   }
 
@@ -171,6 +177,9 @@ enum LLMProviderType: Codable {
       return .chatGPTClaude
     case "chatgpt_claude":
       return .chatGPTClaude
+    case "openrouter":
+      let model = defaults.string(forKey: "openrouterModelId") ?? "deepseek/deepseek-v4-flash"
+      return .openRouter(modelId: model)
     default:
       return nil
     }
@@ -182,6 +191,7 @@ enum LLMProviderID: String, Codable, CaseIterable {
   case dayflow
   case ollama
   case chatGPTClaude = "chatgpt_claude"
+  case openRouter = "openrouter"
 
   var analyticsName: String {
     switch self {
@@ -193,6 +203,8 @@ enum LLMProviderID: String, Codable, CaseIterable {
       return "ollama"
     case .chatGPTClaude:
       return "chat_cli"
+    case .openRouter:
+      return "openrouter"
     }
   }
 
@@ -206,6 +218,8 @@ enum LLMProviderID: String, Codable, CaseIterable {
       return .ollama
     case .chatGPTClaude:
       return .chatGPTClaude
+    case .openRouter:
+      return .openRouter
     }
   }
 
@@ -219,6 +233,8 @@ enum LLMProviderID: String, Codable, CaseIterable {
       return "local"
     case .chatGPTClaude:
       return chatTool == .claude ? "claude" : "chatgpt"
+    case .openRouter:
+      return "openrouter"
     }
   }
 }

--- a/Dayflow/Dayflow/Core/AI/OpenRouterProvider+Transcription.swift
+++ b/Dayflow/Dayflow/Core/AI/OpenRouterProvider+Transcription.swift
@@ -1,0 +1,322 @@
+//
+//  OpenRouterProvider+Transcription.swift
+//  Dayflow
+//
+//  Screenshot transcription via OpenRouter's vision API.
+//  Sends screen grabs as base64 images in the OpenAI chat format.
+//
+
+import AppKit
+import Foundation
+
+extension OpenRouterProvider {
+
+    /// Transcribe a batch of screenshots into observations using the vision model.
+    func transcribeScreenshots(
+        _ screenshots: [Screenshot],
+        batchStartTime: Date,
+        batchId: Int64?
+    ) async throws -> (observations: [Observation], log: LLMCall) {
+        let callStart = Date()
+
+        guard !screenshots.isEmpty else {
+            return ([], LLMCall(timestamp: callStart, latency: 0, input: "", output: ""))
+        }
+
+        // Limit how many screenshots we send to avoid token blowout
+        let maxFrames = 20
+        let sampled = screenshots.count <= maxFrames
+            ? screenshots
+            : stride(from: 0, to: screenshots.count, by: max(1, screenshots.count / maxFrames))
+                .map { screenshots[$0] }
+
+        // Build timestamped image content
+        var contentParts: [ORContentPart] = []
+        let transcriptionPrompt = """
+        You are analyzing a series of screenshots from someone's computer taken over a period of time.
+        Describe what the person was doing in each screenshot. Be specific about:
+        - What application or website is visible
+        - What they appear to be working on
+        - Any notable content on screen (files, messages, code, etc.)
+
+        Keep each description to 1-2 sentences. Focus on being factual and specific.
+        Timestamps are shown in the format MM:SS from the start of the recording.
+        """
+
+        contentParts.append(ORContentPart(type: "text", text: transcriptionPrompt, image_url: nil))
+
+        for (index, screenshot) in sampled.enumerated() {
+            // Better screenshot timestamps from actual capture time
+            let timing = Double(screenshot.capturedAt) - batchStartTime.timeIntervalSince1970
+            let minutes = Int(timing) / 60
+            let seconds = Int(timing) % 60
+
+            // Get the screenshot image data
+            guard let imageData = try? Data(contentsOf: screenshot.fileURL) else {
+                continue
+            }
+
+            // Downsize to ~720p
+            let resized = resizeImageData(imageData, maxDimension: 720)
+            let base64 = resized.base64EncodedString()
+
+            let timeLabel = String(format: "[%02d:%02d]", minutes, seconds)
+            contentParts.append(ORContentPart(type: "text", text: timeLabel, image_url: nil))
+            contentParts.append(ORContentPart(
+                type: "image_url",
+                text: nil,
+                image_url: ORContentPart.ORImageURL(url: "data:image/jpeg;base64,\(base64)")
+            ))
+        }
+
+        let message = ORMessage(role: "user", content: contentParts)
+
+        let (response, usedModel) = try await callChatAPI(
+            messages: [message],
+            operation: "transcribe_screenshots",
+            batchId: batchId,
+            maxRetries: 2
+        )
+
+        let rawText = response.choices.first?.message.content ?? ""
+
+        // Parse the text into observations
+        let observations = parseTranscriptionResponse(rawText, batchStartTime: batchStartTime, screenshotCount: screenshots.count)
+
+        let latency = Date().timeIntervalSince(callStart)
+        let log = LLMCall(
+            timestamp: callStart,
+            latency: latency,
+            input: "Transcribed \(screenshots.count) screenshots via \(usedModel)",
+            output: rawText
+        )
+
+        return (observations, log)
+    }
+
+    // MARK: - Transcription Parsing
+
+    private func parseTranscriptionResponse(
+        _ text: String,
+        batchStartTime: Date,
+        screenshotCount: Int
+    ) -> [Observation] {
+        // Split into lines and try to extract observations
+        let lines = text.components(separatedBy: .newlines).filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        guard !lines.isEmpty else { return [] }
+
+        var observations: [Observation] = []
+        let baseTimestamp = Int(batchStartTime.timeIntervalSince1970)
+        let interval = max(1, (screenshotCount * 10) / max(1, lines.count))
+
+        for (i, line) in lines.enumerated() {
+            let clean = line
+                .replacingOccurrences(of: #"^\[\d{2}:\d{2}\]\s*"#, with: "", options: .regularExpression)
+                .trimmingCharacters(in: .whitespaces)
+
+            guard !clean.isEmpty else { continue }
+
+            let startTs = baseTimestamp + (i * interval)
+            let endTs = startTs + interval
+
+            observations.append(Observation(
+                observation: clean,
+                startTs: startTs,
+                endTs: endTs,
+                apps: extractApps(from: clean)
+            ))
+        }
+
+        return observations
+    }
+
+    private func extractApps(from text: String) -> [String] {
+        let knownApps = [
+            "Xcode", "VS Code", "Cursor", "Zed", "Terminal", "iTerm",
+            "Chrome", "Safari", "Firefox", "Arc", "Brave",
+            "Slack", "Discord", "Teams", "Zoom",
+            "Mail", "Gmail", "Outlook",
+            "Finder", "Notes", "Notion", "Obsidian",
+            "Photoshop", "Figma", "Sketch",
+            "Spotify", "Music", "Calendar",
+            "GitHub", "GitLab",
+        ]
+        let lower = text.lowercased()
+        return knownApps.filter { lower.contains($0.lowercased()) }
+    }
+
+    // MARK: - Image Resizing
+
+    private func resizeImageData(_ data: Data, maxDimension: CGFloat) -> Data {
+        guard let image = NSImage(data: data) else { return data }
+
+        let size = image.size
+        let scale = min(maxDimension / max(size.width, size.height), 1.0)
+        let newWidth = max(1, Int(size.width * scale))
+        let newHeight = max(1, Int(size.height * scale))
+        let newSize = NSSize(width: CGFloat(newWidth), height: CGFloat(newHeight))
+
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return data
+        }
+
+        guard let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: newWidth,
+            pixelsHigh: newHeight,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ),
+        let ctx = NSGraphicsContext(bitmapImageRep: bitmap) else {
+            return data
+        }
+
+        bitmap.size = newSize
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = ctx
+        image.draw(in: NSRect(origin: .zero, size: newSize))
+        NSGraphicsContext.restoreGraphicsState()
+
+        return bitmap.representation(using: .jpeg, properties: [.compressionFactor: 0.7]) ?? data
+    }
+}
+
+// MARK: - Text Generation (LLMCall compatible)
+
+extension OpenRouterProvider {
+    func generateTextStreaming(prompt: String) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    let result = try await self.generateText(prompt: prompt)
+                    continuation.yield(result.text)
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Activity Card Generation
+
+extension OpenRouterProvider {
+    func generateActivityCards(
+        observations: [Observation],
+        context: ActivityGenerationContext,
+        batchId: Int64?
+    ) async throws -> (cards: [ActivityCardData], log: LLMCall) {
+        let callStart = Date()
+
+        let sortedObs = observations.sorted { $0.startTs < $1.startTs }
+        guard let first = sortedObs.first, let last = sortedObs.last else {
+            return ([], LLMCall(timestamp: callStart, latency: 0, input: "", output: ""))
+        }
+
+        let obsText = sortedObs.map { obs in
+            let start = formatTimestamp(obs.startTs)
+            let end = formatTimestamp(obs.endTs)
+            return "\(start)-\(end): \(obs.observation)"
+        }.joined(separator: "\n")
+
+        let categoriesDesc = context.categories.map { "\($0.name): \($0.description ?? "")" }.joined(separator: "\n")
+
+        let prompt = """
+        You are analyzing a work journal. Based on the following observations, create a single activity card.
+        Categories available:
+        \(categoriesDesc)
+
+        Observations:
+        \(obsText)
+
+        Return a JSON object with these fields:
+        {
+          "category": "one of the categories above",
+          "subcategory": "a more specific subcategory",
+          "title": "a concise title (max 8 words)",
+          "summary": "1-2 sentence summary of what was done"
+        }
+
+        Return ONLY valid JSON, no other text.
+        """
+
+        let raw = try await callTextAPI(prompt, operation: "generate_cards", expectJSON: true, batchId: batchId, maxTokens: 2000)
+
+        // Parse JSON response
+        let card = parseActivityCard(raw, startTime: formatTimestamp(first.startTs), endTime: formatTimestamp(last.endTs))
+
+        let log = LLMCall(
+            timestamp: callStart,
+            latency: Date().timeIntervalSince(callStart),
+            input: prompt,
+            output: raw
+        )
+
+        return ([card], log)
+    }
+
+    private func parseActivityCard(_ jsonText: String, startTime: String, endTime: String) -> ActivityCardData {
+        struct RawCard: Codable {
+            let category: String?
+            let subcategory: String?
+            let title: String?
+            let summary: String?
+        }
+
+        // Try to extract JSON from response
+        let cleaned: String
+        if let start = jsonText.firstIndex(of: "{"),
+           let end = jsonText.lastIndex(of: "}") {
+            cleaned = String(jsonText[start...end])
+        } else {
+            cleaned = jsonText
+        }
+
+        if let data = cleaned.data(using: .utf8),
+           let parsed = try? JSONDecoder().decode(RawCard.self, from: data) {
+            return ActivityCardData(
+                startTime: startTime,
+                endTime: endTime,
+                category: parsed.category ?? "General",
+                subcategory: parsed.subcategory ?? "",
+                title: parsed.title ?? "Activity",
+                summary: parsed.summary ?? observationsSummary(from: cleaned),
+                detailedSummary: "",
+                distractions: nil,
+                appSites: nil
+            )
+        }
+
+        return ActivityCardData(
+            startTime: startTime,
+            endTime: endTime,
+            category: "General",
+            subcategory: "",
+            title: "Activity",
+            summary: observationsSummary(from: cleaned),
+            detailedSummary: "",
+            distractions: nil,
+            appSites: nil
+        )
+    }
+
+    private func observationsSummary(from text: String) -> String {
+        let lines = text.components(separatedBy: .newlines).filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        return lines.prefix(3).joined(separator: "; ")
+    }
+
+    private func formatTimestamp(_ ts: Int) -> String {
+        let date = Date(timeIntervalSince1970: TimeInterval(ts))
+        let fmt = DateFormatter()
+        fmt.dateFormat = "h:mm a"
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = TimeZone.current
+        return fmt.string(from: date)
+    }
+}

--- a/Dayflow/Dayflow/Core/AI/OpenRouterProvider.swift
+++ b/Dayflow/Dayflow/Core/AI/OpenRouterProvider.swift
@@ -1,0 +1,318 @@
+//
+//  OpenRouterProvider.swift
+//  Dayflow
+//
+//  OpenRouter-powered LLM provider. Uses the OpenAI-compatible chat completions
+//  endpoint (https://openrouter.ai/api/v1/chat/completions) with Bearer auth.
+//  Supports vision for screenshot transcription and text for card generation + chat.
+//
+
+import AppKit
+import Foundation
+
+// MARK: - API Types
+
+struct ORChatRequest: Codable {
+    let model: String
+    let messages: [ORMessage]
+    var temperature: Double = 0.7
+    var max_tokens: Int = 4000
+    var stream: Bool = false
+    var response_format: ORResponseFormat?
+
+    struct ORResponseFormat: Codable {
+        let type: String // "text" or "json_object"
+    }
+}
+
+struct ORMessage: Codable {
+    let role: String
+    let content: [ORContentPart]
+}
+
+struct ORContentPart: Codable {
+    let type: String
+    let text: String?
+    let image_url: ORImageURL?
+
+    struct ORImageURL: Codable {
+        let url: String
+    }
+}
+
+struct ORChatResponse: Codable {
+    let choices: [ORChoice]
+    let usage: ORUsage?
+
+    struct ORChoice: Codable {
+        let message: ORResponseMessage
+    }
+
+    struct ORResponseMessage: Codable {
+        let content: String?
+    }
+
+    struct ORUsage: Codable {
+        let prompt_tokens: Int?
+        let completion_tokens: Int?
+        let total_tokens: Int?
+    }
+}
+
+struct ORModelListResponse: Codable {
+    let data: [ORModelEntry]
+}
+
+struct ORModelEntry: Codable, Identifiable {
+    let id: String
+    let name: String?
+    let created: Int?
+    let description: String?
+    let pricing: ORModelPricing?
+    let context_length: Int?
+
+    var modelID: String { id }
+
+    struct ORModelPricing: Codable {
+        let prompt: String?
+        let completion: String?
+    }
+}
+
+// MARK: - Error
+
+enum ORProviderError: LocalizedError {
+    case noAPIKey
+    case invalidURL
+    case httpError(Int, String)
+    case parseError(String)
+    case networkError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .noAPIKey: return "OpenRouter API key not configured. Add it in Settings > Providers."
+        case .invalidURL: return "Invalid OpenRouter API URL."
+        case .httpError(let code, let body): return "OpenRouter returned HTTP \(code): \(body)"
+        case .parseError(let msg): return "Failed to parse OpenRouter response: \(msg)"
+        case .networkError(let msg): return "OpenRouter network error: \(msg)"
+        }
+    }
+}
+
+// MARK: - Provider
+
+final class OpenRouterProvider {
+    static let defaultBaseURL = "https://openrouter.ai/api/v1"
+    static let defaultModel = "deepseek/deepseek-v4-flash"
+
+    let baseURL: String
+    let screenshotInterval: TimeInterval = 10
+
+    private var apiKey: String? {
+        KeychainManager.shared.retrieve(for: "openrouter")
+    }
+
+    var savedModelId: String {
+        UserDefaults.standard.string(forKey: "openrouterModelId") ?? Self.defaultModel
+    }
+
+    init(baseURL: String = defaultBaseURL) {
+        self.baseURL = baseURL
+    }
+
+    // MARK: - URL Building
+
+    private func url(_ path: String) -> URL? {
+        let trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard var components = URLComponents(string: trimmed) else { return nil }
+        var normalizedPath = components.path
+        if normalizedPath.hasSuffix("/") { normalizedPath = String(normalizedPath.dropLast()) }
+        let fullPath = normalizedPath + path
+        components.path = fullPath
+        return components.url
+    }
+
+    private var chatCompletionsURL: URL? { url("/chat/completions") }
+    private var modelsURL: URL? { url("/models") }
+
+    // MARK: - Common HTTP Call
+
+    private func makeRequest(path: String, body: Data?) -> URLRequest? {
+        guard let url = url(path) else { return nil }
+        guard let key = apiKey, !key.isEmpty else { return nil }
+        var req = URLRequest(url: url)
+        req.httpMethod = body != nil ? "POST" : "GET"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        req.setValue("Dayflow/1.0", forHTTPHeaderField: "HTTP-Referer")
+        req.setValue("Dayflow", forHTTPHeaderField: "X-Title")
+        req.httpBody = body
+        req.timeoutInterval = 120
+        return req
+    }
+
+    /// Sends a chat request and returns the parsed response + usage info.
+    func callChatAPI(
+        model: String? = nil,
+        messages: [ORMessage],
+        operation: String,
+        batchId: Int64? = nil,
+        maxRetries: Int = 3,
+        responseFormat: ORChatRequest.ORResponseFormat? = nil
+    ) async throws -> (response: ORChatResponse, model: String) {
+        guard let key = apiKey, !key.isEmpty else { throw ORProviderError.noAPIKey }
+
+        let actualModel = model ?? savedModelId
+        var request = ORChatRequest(
+            model: actualModel,
+            messages: messages,
+            temperature: 0.7,
+            max_tokens: 8000,
+            stream: false
+        )
+        request.response_format = responseFormat
+        let body = try JSONEncoder().encode(request)
+
+        guard let urlRequest = makeRequest(path: "/chat/completions", body: body) else {
+            throw ORProviderError.invalidURL
+        }
+
+        let callGroupId = UUID().uuidString
+        var lastError: Error?
+
+        for attempt in 0..<max(maxRetries, 1) {
+            let start = Date()
+            let ctx = LLMCallContext(
+                batchId: batchId,
+                callGroupId: callGroupId,
+                attempt: attempt + 1,
+                provider: "openrouter",
+                model: actualModel,
+                operation: operation,
+                requestMethod: "POST",
+                requestURL: urlRequest.url,
+                requestHeaders: urlRequest.allHTTPHeaderFields,
+                requestBody: body,
+                startedAt: start
+            )
+
+            do {
+                let (data, response) = try await URLSession.shared.data(for: urlRequest)
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    throw ORProviderError.networkError("Invalid response type")
+                }
+
+                guard httpResponse.statusCode == 200 else {
+                    let errorBody = String(data: data, encoding: .utf8) ?? "Unknown"
+                    let headers: [String: String] = httpResponse.allHeaderFields.reduce(into: [:]) {
+                        if let k = $1.key as? String, let v = $1.value as? CustomStringConvertible {
+                            $0[k] = v.description
+                        }
+                    }
+                    LLMLogger.logFailure(
+                        ctx: ctx,
+                        http: LLMHTTPInfo(httpStatus: httpResponse.statusCode, responseHeaders: headers, responseBody: data),
+                        finishedAt: Date(),
+                        errorDomain: "OpenRouterProvider",
+                        errorCode: httpResponse.statusCode,
+                        errorMessage: errorBody
+                    )
+                    throw ORProviderError.httpError(httpResponse.statusCode, errorBody)
+                }
+
+                let decoded = try JSONDecoder().decode(ORChatResponse.self, from: data)
+                let headers: [String: String] = httpResponse.allHeaderFields.reduce(into: [:]) {
+                    if let k = $1.key as? String, let v = $1.value as? CustomStringConvertible {
+                        $0[k] = v.description
+                    }
+                }
+                LLMLogger.logSuccess(ctx: ctx, http: LLMHTTPInfo(httpStatus: 200, responseHeaders: headers, responseBody: data), finishedAt: Date())
+                return (decoded, actualModel)
+
+            } catch {
+                lastError = error
+                print("[OR] Request failed (attempt \(attempt + 1)/\(maxRetries)): \(error.localizedDescription)")
+                if attempt < maxRetries - 1 {
+                    let delay = pow(2.0, Double(attempt)) * 2.0
+                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                } else if let orError = error as? ORProviderError {
+                    throw orError
+                } else {
+                    throw ORProviderError.networkError(error.localizedDescription)
+                }
+            }
+        }
+
+        throw lastError ?? ORProviderError.networkError("Request failed after \(maxRetries) attempts")
+    }
+
+    // MARK: - Text-Only Helper
+
+    func callTextAPI(
+        _ prompt: String,
+        operation: String,
+        model: String? = nil,
+        expectJSON: Bool = false,
+        batchId: Int64? = nil,
+        maxRetries: Int = 3,
+        maxTokens: Int = 4000
+    ) async throws -> String {
+        let systemPrompt = expectJSON
+            ? "You are a helpful assistant. Always respond with valid JSON."
+            : "You are a helpful assistant."
+
+        let messages: [ORMessage] = [
+            ORMessage(role: "system", content: [ORContentPart(type: "text", text: systemPrompt, image_url: nil)]),
+            ORMessage(role: "user", content: [ORContentPart(type: "text", text: prompt, image_url: nil)])
+        ]
+
+        let (response, _) = try await callChatAPI(
+            model: model,
+            messages: messages,
+            operation: operation,
+            batchId: batchId,
+            maxRetries: maxRetries,
+            responseFormat: expectJSON ? ORChatRequest.ORResponseFormat(type: "json_object") : nil
+        )
+        return response.choices.first?.message.content ?? ""
+    }
+
+    // MARK: - Model Listing
+
+    func fetchAvailableModels() async throws -> [ORModelEntry] {
+        guard let key = apiKey, !key.isEmpty else { throw ORProviderError.noAPIKey }
+        guard let req = makeRequest(path: "/models", body: nil) else { throw ORProviderError.invalidURL }
+
+        let (data, response) = try await URLSession.shared.data(for: req)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? "Unknown"
+            throw ORProviderError.httpError((response as? HTTPURLResponse)?.statusCode ?? 0, body)
+        }
+
+        let list = try JSONDecoder().decode(ORModelListResponse.self, from: data)
+        return list.data.sorted { $0.id.lowercased() < $1.id.lowercased() }
+    }
+
+    // MARK: - Text Generation (LLMCall compatible)
+
+    func generateText(prompt: String, maxTokens: Int = 4000) async throws -> (text: String, log: LLMCall) {
+        let callStart = Date()
+        let response = try await callTextAPI(prompt, operation: "generate_text", maxTokens: maxTokens)
+        let log = LLMCall(
+            timestamp: callStart,
+            latency: Date().timeIntervalSince(callStart),
+            input: prompt,
+            output: response
+        )
+        return (response.trimmingCharacters(in: .whitespacesAndNewlines), log)
+    }
+}
+
+// MARK: - Logging Helper
+
+private extension OpenRouterProvider {
+    func logCallDuration(operation: String, duration: TimeInterval, status: Int? = nil) {
+        let statusText = status.map { " status=\($0)" } ?? ""
+        print("⏱️ [openrouter] \(operation) \(String(format: "%.2f", duration))s\(statusText)")
+    }
+}

--- a/Dayflow/Dayflow/Views/Onboarding/LLMProviderSetupView.swift
+++ b/Dayflow/Dayflow/Views/Onboarding/LLMProviderSetupView.swift
@@ -15,6 +15,8 @@ struct LLMProviderSetupView: View {
       return "Use local AI"
     case "chatgpt_claude":
       return "Connect ChatGPT or Claude"
+    case "openrouter":
+      return "Connect OpenRouter"
     default:
       return "Gemini"
     }

--- a/Dayflow/Dayflow/Views/Onboarding/OnboardingLLMSelectionView.swift
+++ b/Dayflow/Dayflow/Views/Onboarding/OnboardingLLMSelectionView.swift
@@ -222,6 +222,40 @@ struct OnboardingLLMSelectionView: View {
         }
       ),
 
+      // OpenRouter card
+      FlexibleProviderCard(
+        id: "openrouter",
+        title: "OpenRouter",
+        badgeText: "NEW",
+        badgeType: .blue,
+        icon: "globe",
+        features: [
+          ("Access 300+ models (DeepSeek, Claude, GPT, Gemini, and more)", true),
+          ("Pay per token, no subscriptions needed", true),
+          ("Vision-capable models for screenshot analysis", true),
+          ("Requires an OpenRouter API key (free to sign up)", false),
+          ("Requires internet connection", false),
+        ],
+        isSelected: selectedProvider == "openrouter",
+        buttonMode: .onboarding(onProceed: {
+          if selectedProvider == "openrouter" {
+            saveProviderSelection()
+            onNext("openrouter")
+          } else {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.9)) {
+              didUserSelectProvider = true
+              selectedProvider = "openrouter"
+            }
+          }
+        }),
+        onSelect: {
+          withAnimation(.spring(response: 0.3, dampingFraction: 0.9)) {
+            didUserSelectProvider = true
+            selectedProvider = "openrouter"
+          }
+        }
+      ),
+
       /*
       // Dayflow Pro card
       FlexibleProviderCard(
@@ -273,6 +307,8 @@ struct OnboardingLLMSelectionView: View {
       providerType = .dayflowBackend()
     case "chatgpt_claude":
       providerType = .chatGPTClaude
+    case "openrouter":
+      providerType = .openRouter()
     default:
       providerType = .geminiDirect
     }

--- a/Dayflow/Dayflow/Views/Onboarding/ProviderSetupState.swift
+++ b/Dayflow/Dayflow/Views/Onboarding/ProviderSetupState.swift
@@ -7,6 +7,7 @@ class ProviderSetupState: ObservableObject {
   @Published var currentStepIndex: Int = 0
   @Published var apiKey: String = ""
   @Published var geminiAPIKeySaveError: String?
+  @Published var activeProviderType: String = "gemini"
   @Published var hasTestedConnection: Bool = false
   @Published var testSuccessful: Bool = false
   @Published var geminiModel: GeminiModel
@@ -14,8 +15,11 @@ class ProviderSetupState: ObservableObject {
   @Published var localEngine: LocalEngine = .lmstudio
   @Published var localBaseURL: String = LocalEngine.lmstudio.defaultBaseURL
   @Published var localModelId: String = LocalModelPreferences.defaultModelId(for: .lmstudio)
-  @Published var localAPIKey: String = UserDefaults.standard.string(forKey: "llmLocalAPIKey") ?? ""
-  // CLI detection
+  @Published var localAPIKey: String? = UserDefaults.standard.string(forKey: "llmLocalAPIKey") ?? ""
+    // OpenRouter configuration
+    @Published var openRouterModelId: String = UserDefaults.standard.string(forKey: "openrouterModelId") ?? "deepseek/deepseek-v4-flash"
+    @Published var openRouterAPIKeySaveError: String?
+    // CLI detection
   @Published var codexCLIStatus: CLIDetectionState = .unknown
   @Published var claudeCLIStatus: CLIDetectionState = .unknown
   @Published var isCheckingCLIStatus: Bool = false
@@ -64,6 +68,7 @@ class ProviderSetupState: ObservableObject {
   }
 
   func configureSteps(for provider: String) {
+    activeProviderType = provider
     switch provider {
     case "ollama":
       steps = [
@@ -127,6 +132,28 @@ class ProviderSetupState: ObservableObject {
       claudeCLIReport = nil
       isCheckingCLIStatus = false
       hasStartedCLICheck = false
+    case "openrouter":
+      steps = [
+        SetupStep(
+          id: "getkey", title: "Get API key",
+          contentType: .apiKeyInstructions),
+        SetupStep(
+          id: "enterkey", title: "Enter API key",
+          contentType: .apiKeyInput),
+        SetupStep(
+          id: "model", title: "Choose model",
+          contentType: .information(
+            "Model Selection",
+            "You can change the model anytime in Settings. Default: deepseek/deepseek-v4-flash")),
+        SetupStep(
+          id: "verify", title: "Test connection",
+          contentType: .information(
+            "Test Connection", "Click the button below to verify your API key works with OpenRouter.")),
+        SetupStep(
+          id: "complete", title: "Complete",
+          contentType: .information(
+            "All set!", "OpenRouter is now configured and ready to use with Dayflow.")),
+      ]
     default:  // gemini
       steps = [
         SetupStep(
@@ -150,7 +177,11 @@ class ProviderSetupState: ObservableObject {
   func goNext() {
     // Save API key to keychain when moving from API key input step
     if currentStep.contentType.isApiKeyInput && !apiKey.isEmpty {
-      guard persistGeminiAPIKey(source: "onboarding_step") else { return }
+      if activeProviderType == "openrouter" {
+        guard persistOpenRouterAPIKey(source: "onboarding_step") else { return }
+      } else {
+        guard persistGeminiAPIKey(source: "onboarding_step") else { return }
+      }
     }
 
     if currentStepIndex < steps.count - 1 {
@@ -228,6 +259,31 @@ class ProviderSetupState: ObservableObject {
       persistGeminiModelSelection(source: source)
     } else {
       geminiAPIKeySaveError =
+        "Couldn't save your API key to Keychain. Please unlock Keychain and try again."
+    }
+    return stored
+  }
+
+  @discardableResult
+  func persistOpenRouterAPIKey(source: String) -> Bool {
+    let cleaned = apiKey.components(separatedBy: .whitespacesAndNewlines).joined()
+    guard !cleaned.isEmpty else {
+      openRouterAPIKeySaveError = nil
+      return true
+    }
+
+    if cleaned != apiKey {
+      apiKey = cleaned
+    }
+
+    let stored = KeychainManager.shared.store(cleaned, for: "openrouter")
+    if stored {
+      openRouterAPIKeySaveError = nil
+      hasTestedConnection = false
+      testSuccessful = false
+      UserDefaults.standard.set(openRouterModelId, forKey: "openrouterModelId")
+    } else {
+      openRouterAPIKeySaveError =
         "Couldn't save your API key to Keychain. Please unlock Keychain and try again."
     }
     return stored

--- a/Dayflow/Dayflow/Views/UI/ChatView+Actions.swift
+++ b/Dayflow/Dayflow/Views/UI/ChatView+Actions.swift
@@ -347,6 +347,8 @@ extension ChatView {
       chatCLIPreferredTool = "codex"
     case .claude:
       chatCLIPreferredTool = "claude"
+    case .openRouter:
+      break
     }
   }
 
@@ -358,6 +360,11 @@ extension ChatView {
       return codexDetected
     case .claude:
       return claudeDetected
+    case .openRouter:
+      if let key = KeychainManager.shared.retrieve(for: "openrouter") {
+        return !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      }
+      return false
     }
   }
 

--- a/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
@@ -261,6 +261,8 @@ final class ProvidersSettingsViewModel: ObservableObject {
       currentProvider = "ollama"
     case .chatGPTClaude:
       currentProvider = "chatgpt_claude"
+    case .openRouter:
+      currentProvider = "openrouter"
     }
     hasLoadedProvider = true
   }
@@ -517,6 +519,14 @@ final class ProvidersSettingsViewModel: ObservableObject {
       let preferredTool = (UserDefaults.standard.string(forKey: "chatCLIPreferredTool") ?? "")
         .trimmingCharacters(in: .whitespacesAndNewlines)
       return !preferredTool.isEmpty
+    case "openrouter":
+      if UserDefaults.standard.bool(forKey: "openrouterSetupComplete") {
+        return true
+      }
+      if let key = KeychainManager.shared.retrieve(for: "openrouter") {
+        return !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      }
+      return false
     case "dayflow":
       return isDayflowProActive
     default:


### PR DESCRIPTION
## Summary

Adds a dedicated OpenRouter provider for Dayflow, enabling access to 300+ models (DeepSeek V4 Flash, Claude, GPT, Gemini, etc.) for screenshot transcription, activity card generation, and dashboard chat.

## Changes

### New files
- **OpenRouterProvider.swift** — Core provider with OpenAI-compatible chat completions, model fetching from /v1/models, retry logic (exponential backoff), Keychain auth, structured error handling, and LLM telemetry integration
- **OpenRouterProvider+Transcription.swift** — Vision-based screenshot transcription, activity card generation with JSON parsing, image resizing (~720p), and timestamp extraction

### Integration
- Extended LLMProviderType, LLMProviderID, and DashboardChatProvider enums
- Wired into LLMService for batch processing, text generation, and chat streaming
- Full onboarding flow: API key entry, model selection, connection test
- Settings UI with provider config check and routing
- Dashboard chat availability check via Keychain

### Audit fixes
All findings from Claude Code audit addressed:
- Safe bitmap allocation (removed force-unwrap crash)
- Non-retryable 4xx errors skip retries
- Screenshot timestamps use actual capture time
- Colorspace corrected to .deviceRGB
- Zero-size dimension crash guard
- Optional content handling for model refusals
- response_format support for structured JSON output