### PR TITLE
feat: add MiniMax M3 as a cloud AI provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,130 @@
+# Dayflow — Project Agent Notes
+
+This file captures project-specific knowledge that any coding agent
+(Mavis, Mavis, or anything else consuming the `AGENTS.md` spec) needs
+to be productive inside this repo. Keep it terse, factual, and current.
+
+## Repository topology
+
+| Role  | Remote                                              | Default branch |
+| ----- | --------------------------------------------------- | -------------- |
+| fork  | `https://github.com/M3NT1/Dayflow_M3NT1.git`        | `main`         |
+| upstream | `https://github.com/JerryZLiu/dayflow.git`       | `main`         |
+
+- `origin`  → upstream (`JerryZLiu/dayflow`)
+- `myfork`  → personal fork (`M3NT1/Dayflow_M3NT1`)
+- All work-in-progress lives on `myfork/feat/*` branches, never on `main` directly.
+- The active development branch right now is **`feat/minimax-m3-provider`**
+  (MiniMax M3 cloud provider — added in commit `3bc167e`, then iterated
+  to `23ff29f`). The fix described in
+  `Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift`
+  (adding the `case "minimax":` branch to `isProviderConfigured`) is
+  the latest patch on top of that branch.
+
+## Build & run
+
+- The project is a SwiftUI macOS app opened with Xcode 26
+  (`/Applications/Xcode.app`).
+- The user's `xcode-select` points to Command Line Tools, not Xcode.
+  All `xcodebuild` invocations need `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer`
+  in the environment, or build silently fails to find the toolchain.
+- The user has no `Mac Development` signing certificate for the
+  `L75WYD8X4Y` team, so every build must pass `CODE_SIGNING_ALLOWED=NO`
+  (or equivalent) or it will fail with a signing error.
+- Build products are NOT kept inside the repo. After every successful
+  build, the freshly built `Dayflow.app` is copied from
+  `~/Library/Developer/Xcode/DerivedData/Dayflow-*/Build/Products/Debug/Dayflow.app`
+  into **`/Users/kasnyiklaszlo/Documents/MENTIFLOW/dist/Dayflow.app`**
+  for the user to launch. Always use `mavis-trash` (not `rm`) for the
+  old `dist/Dayflow.app` so it stays recoverable.
+- `gh` CLI is available and authenticated. PRs targeting the upstream
+  Dayflow repo are created with
+  `gh pr create --repo JerryZLiu/dayflow --base main --head M3NT1:<branch>`.
+
+## Project layout
+
+```
+Dayflow/
+  Dayflow.xcodeproj
+  Dayflow/
+    App/             — AppDelegate, app lifecycle
+    Config/          — Build-time configuration (LocalSecrets.xcconfig is gitignored)
+    Core/            — Business logic
+      AI/            — LLM provider implementations
+        MiniMaxProvider*.swift    — MiniMax M3 provider
+        GeminiProvider*.swift     — Gemini provider
+        ChatCLIProvider*.swift    — OpenAI/Claude CLI providers
+        OllamaProvider*.swift     — Local (Ollama / LM Studio) provider
+        ModelCatalog.swift        — Curated + live model lists
+        LLMService.swift          — Main dispatch, failover routing
+    Models/          — Data models
+    Recording/       — Screen recording, storage, timeline cards
+    Utilities/       — Helpers (e.g. MiniMaxAPIHelper)
+    Views/
+      Onboarding/    — First-run flow
+      UI/            — Main UI
+        Settings/    — Preferences tabs
+          SettingsProvidersTabView.swift       — Provider list UI
+          ProvidersSettingsViewModel.swift      — Provider logic, routing
+          ProvidersSettingsViewModel+PromptOverrides.swift
+  DayflowTests/      — Unit tests (very sparse; only ChatCLI + DailyRecap)
+  DayflowUITests/    — UI tests
+  docs/              — Appcast, release notes
+```
+
+## LLM provider model
+
+Each provider has a **canonical id** and a **display id** that may differ
+when the underlying engine is swappable (e.g. `chatgpt` / `claude` ↔
+`chatgpt_claude`). The provider's status is tracked by:
+
+| Canonical id      | Keychain key            | Setup-complete flag        | Provider class            |
+| ----------------- | ----------------------- | -------------------------- | ------------------------- |
+| `gemini`          | `"gemini"`              | `geminiSetupComplete`      | GeminiProvider            |
+| `minimax`         | `"minimax"`             | `minimaxSetupComplete`     | MiniMaxProvider           |
+| `ollama`          | (UserDefaults only)     | `ollamaSetupComplete`      | OllamaProvider / custom   |
+| `chatgpt_claude`  | (CLI binary)            | `chatgpt_claudeSetupComplete` | ChatCLIProvider        |
+| `dayflow`         | (Dayflow Pro)           | (derived from Pro status)  | (hosted)                  |
+
+**Critical gotcha — every new provider needs a `case` in three places:**
+
+1. `ProvidersSettingsViewModel.isProviderConfigured(_:)` — otherwise the
+   provider is never recognised as "set up" and the "Set primary" /
+   "Set secondary" buttons loop the user back into the setup wizard
+   (this is the bug fixed for MiniMax; copy the `gemini` branch as the
+   template: check Keychain first, fall back to the
+   `*SetupComplete` UserDefaults flag).
+2. `ProvidersSettingsViewModel.canonicalProviderId(for:)` / `displayProviderId`
+   — only needs touching if the provider has variant display ids.
+3. `CompactProviderInfo.providerTableName` — only for custom table labels.
+
+The MiniMax M3 fix added the missing `case "minimax":` to
+`isProviderConfigured` and nothing else was needed.
+
+## Routing logic (Settings → Providers tab)
+
+- `routingProviders` is the list of cards in the "Failover routing"
+  section. Each row shows: status badge, summary line, and an
+  action row with one or more of `Setup` / `Edit configuration` /
+  `Set primary` / `Set secondary` / `Unset secondary`.
+- `isProviderConfigured` drives the "CONFIGURED" / "NOT SET" badge
+  and whether the `Setup` button is shown.
+- `canAssignSecondary` requires `isProviderConfigured == true` AND
+  that the target is not the same canonical provider as the current
+  primary. So **if `isProviderConfigured` lies, the secondary slot
+  will never be assignable** even after a successful setup wizard.
+- `beginProviderSetup(_:role:)` stores the intent (`pendingSetupRole`)
+  before opening the modal. On `handleProviderSetupCompletion(_:)`,
+  the stored role decides whether to call `assignPrimaryProvider` or
+  `assignSecondaryProvider`.
+
+## Conventions
+
+- Commit messages follow Conventional Commits: `feat:`, `fix:`,
+  `settings:`, `release:`, etc.
+- New code goes through the user's personal fork first; MRs are
+  opened against `JerryZLiu/dayflow: main`.
+- The `CLAUDE.md` / `claude.md` files are git-ignored, so do not
+  commit agent memory there. Use `AGENTS.md` (this file) instead.
+- The `dist/` folder is rebuilt on every iteration; never edit files
+  inside `Dayflow.app` directly — they will be overwritten.

--- a/Dayflow/Dayflow/App/AppDelegate.swift
+++ b/Dayflow/Dayflow/App/AppDelegate.swift
@@ -266,6 +266,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             case .dayflowBackend: return "dayflow"
             case .ollamaLocal: return "ollama"
             case .chatGPTClaude: return "chat_cli"
+            case .minimax: return "minimax"
             }
           }()
         ])

--- a/Dayflow/Dayflow/Core/AI/ChatCLIProvider+ActivityCards.swift
+++ b/Dayflow/Dayflow/Core/AI/ChatCLIProvider+ActivityCards.swift
@@ -32,10 +32,12 @@ extension ChatCLIProvider {
     let effort: String?
     switch tool {
     case .claude:
-      model = "sonnet"
+      // Prefer the user-selected model from Settings; fall back to the
+      // previous default ("sonnet") if nothing is configured.
+      model = defaultModel ?? "sonnet"
       effort = nil
     case .codex:
-      model = "gpt-5.4"
+      model = defaultModel ?? "gpt-5.4"
       effort = "low"
     }
 

--- a/Dayflow/Dayflow/Core/AI/ChatCLIProvider+Transcription.swift
+++ b/Dayflow/Dayflow/Core/AI/ChatCLIProvider+Transcription.swift
@@ -224,10 +224,12 @@ extension ChatCLIProvider {
     let effort: String?
     switch tool {
     case .claude:
-      model = "haiku"
+      // Prefer the user-selected model from Settings; fall back to "haiku"
+      // (the cheapest vision-capable Claude) for users who haven't picked one.
+      model = defaultModel ?? "haiku"
       effort = nil
     case .codex:
-      model = "gpt-5.4-mini"
+      model = defaultModel ?? "gpt-5.4-mini"
       effort = "low"
     }
 

--- a/Dayflow/Dayflow/Core/AI/ChatCLIProvider.swift
+++ b/Dayflow/Dayflow/Core/AI/ChatCLIProvider.swift
@@ -25,9 +25,14 @@ final class ChatCLIProvider {
   let tool: ChatCLITool
   let runner = ChatCLIProcessRunner()
   let config = ChatCLIConfigManager.shared
+  /// When non-nil, this overrides whatever the CLI would otherwise pick as its
+  /// default model. The `LLMService` populates it from `UserDefaults`
+  /// (key: `llmCodexModel` / `llmClaudeModel`) based on which tool is active.
+  let defaultModel: String?
 
-  init(tool: ChatCLITool) {
+  init(tool: ChatCLITool, defaultModel: String? = nil) {
     self.tool = tool
+    self.defaultModel = defaultModel
     config.ensureWorkingDirectory()
   }
 

--- a/Dayflow/Dayflow/Core/AI/DailyRecapModels.swift
+++ b/Dayflow/Dayflow/Core/AI/DailyRecapModels.swift
@@ -49,6 +49,8 @@ enum DailyRecapProvider: String, Codable, CaseIterable, Sendable {
       return preferredTool == "claude" ? .claude : .chatgpt
     case .ollamaLocal:
       return .local
+    case .minimax:
+      return .gemini  // Daily recap falls back to gemini for now; explicit override available
     }
   }
 

--- a/Dayflow/Dayflow/Core/AI/LLMService.swift
+++ b/Dayflow/Dayflow/Core/AI/LLMService.swift
@@ -110,6 +110,25 @@ final class LLMService: LLMServicing {
     OllamaProvider(endpoint: endpoint)
   }
 
+  private func makeMiniMaxProvider() -> MiniMaxProvider? {
+    if let apiKey = KeychainManager.shared.retrieve(for: MiniMaxProvider.keychainKey),
+      !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    {
+      let preference = MiniMaxModelPreference.load()
+      let provider = MiniMaxProvider()
+      if preference.hasUserOverride || preference.modelId != MiniMaxProvider.defaultModelId {
+        UserDefaults.standard.set(preference.modelId, forKey: "llmMiniMaxModelId")
+      }
+      print(
+        "🔐 [LLMService] MiniMax provider ready endpoint=\(provider.endpoint) model=\(provider.savedModelId)"
+      )
+      return provider
+    } else {
+      print("❌ [LLMService] Failed to retrieve MiniMax API key from Keychain")
+      return nil
+    }
+  }
+
   private func makeChatCLIProvider(preferredToolOverride: ChatCLITool? = nil) -> ChatCLIProvider {
     let tool: ChatCLITool
     if let preferredToolOverride {
@@ -228,6 +247,14 @@ final class LLMService: LLMServicing {
       )
     case .chatGPTClaude:
       let provider = makeChatCLIProvider(preferredToolOverride: chatToolOverride)
+      return (
+        actions: BatchProviderActions(
+          transcribeScreenshots: provider.transcribeScreenshots,
+          generateActivityCards: provider.generateActivityCards
+        ), fallbackState: nil
+      )
+    case .minimax:
+      guard let provider = makeMiniMaxProvider() else { throw noProviderError() }
       return (
         actions: BatchProviderActions(
           transcribeScreenshots: provider.transcribeScreenshots,
@@ -519,6 +546,14 @@ final class LLMService: LLMServicing {
           try await provider.generateText(prompt: prompt)
         },
         generateTextStreaming: provider.generateTextStreaming
+      )
+    case .minimax:
+      guard let provider = makeMiniMaxProvider() else { throw noProviderError() }
+      return TextProviderActions(
+        generateText: { prompt in
+          try await provider.generateText(prompt: prompt)
+        },
+        generateTextStreaming: nil
       )
     }
   }

--- a/Dayflow/Dayflow/Core/AI/LLMService.swift
+++ b/Dayflow/Dayflow/Core/AI/LLMService.swift
@@ -137,7 +137,18 @@ final class LLMService: LLMServicing {
       let preferredTool = UserDefaults.standard.string(forKey: "chatCLIPreferredTool") ?? "codex"
       tool = (preferredTool == "claude") ? .claude : .codex
     }
-    return ChatCLIProvider(tool: tool)
+    // Pull the user-selected model out of UserDefaults. The provider falls
+    // back to its built-in default if the key is missing or empty.
+    let defaults = UserDefaults.standard
+    let storedModel: String?
+    switch tool {
+    case .codex:
+      storedModel = defaults.string(forKey: "llmCodexModel")
+    case .claude:
+      storedModel = defaults.string(forKey: "llmClaudeModel")
+    }
+    let model = storedModel?.trimmingCharacters(in: .whitespacesAndNewlines)
+    return ChatCLIProvider(tool: tool, defaultModel: (model?.isEmpty == false) ? model : nil)
   }
 
   private func resolvedChatCLITool(for providerID: LLMProviderID, override: ChatCLITool? = nil)
@@ -168,6 +179,53 @@ final class LLMService: LLMServicing {
     )
   }
 
+  /// Stamp every card with the provider+model that produced it, so the
+  /// timeline / dashboard can show "made by Claude 4.5 Sonnet" without
+  /// having to re-derive it at render time.
+  private func attachMeta(
+    _ cards: [ActivityCardData], providerID: String, model: String
+  ) -> [ActivityCardData] {
+    return cards.map { card in
+      ActivityCardData(
+        startTime: card.startTime,
+        endTime: card.endTime,
+        category: card.category,
+        subcategory: card.subcategory,
+        title: card.title,
+        summary: card.summary,
+        detailedSummary: card.detailedSummary,
+        distractions: card.distractions,
+        appSites: card.appSites,
+        providerId: providerID,
+        modelId: model
+      )
+    }
+  }
+
+  /// Read the user-selected model for a given provider. We pull from
+  /// `UserDefaults` because the settings view-model persists the selection
+  /// there; this is the cheapest way to read it from a non-actor context.
+  private func resolvedModel(for providerID: LLMProviderID) -> String {
+    let defaults = UserDefaults.standard
+    switch providerID {
+    case .gemini:
+      return GeminiModelPreference.load().primary.rawValue
+    case .minimax:
+      return defaults.string(forKey: "llmMiniMaxModelId") ?? MiniMaxProvider.defaultModelId
+    case .ollama:
+      return defaults.string(forKey: "llmLocalModelId") ?? LocalModelPreferences.defaultModelId(
+        for: LocalEngine(rawValue: defaults.string(forKey: "llmLocalEngine") ?? "ollama") ?? .ollama)
+    case .chatGPTClaude:
+      let toolRaw = defaults.string(forKey: "chatCLIPreferredTool") ?? "codex"
+      if toolRaw == "claude" {
+        return defaults.string(forKey: "llmClaudeModel") ?? "claude-sonnet-4-5"
+      }
+      return defaults.string(forKey: "llmCodexModel") ?? "gpt-4o"
+    case .dayflow:
+      return "dayflow-managed"
+    }
+  }
+
   private func makeBatchProvider(
     for providerID: LLMProviderID,
     chatToolOverride: ChatCLITool? = nil
@@ -177,6 +235,8 @@ final class LLMService: LLMServicing {
       guard let provider = makeGeminiProvider() else { throw noProviderError() }
       let gemmaProvider = makeGemmaBackupProvider()
       let fallbackState = GemmaFallbackState()
+      let model = resolvedModel(for: .gemini)
+      let providerID = "gemini"
 
       return (
         actions: BatchProviderActions(
@@ -200,20 +260,23 @@ final class LLMService: LLMServicing {
           generateActivityCards: { [weak self] observations, context, batchId in
             if fallbackState.preferGemma, let gemmaProvider {
               fallbackState.usedGemmaForCardGeneration = true
-              return try await gemmaProvider.generateActivityCards(
+              let (cards, log) = try await gemmaProvider.generateActivityCards(
                 observations: observations, context: context, batchId: batchId)
+              return (self?.attachMeta(cards, providerID: providerID, model: model) ?? cards, log)
             }
 
             do {
-              return try await provider.generateActivityCards(
+              let (cards, log) = try await provider.generateActivityCards(
                 observations: observations, context: context, batchId: batchId)
+              return (self?.attachMeta(cards, providerID: providerID, model: model) ?? cards, log)
             } catch {
               guard let gemmaProvider else { throw error }
               fallbackState.preferGemma = true
               fallbackState.usedGemmaForCardGeneration = true
               self?.logGemmaFallback(operation: "generate_cards", error: error, batchId: batchId)
-              return try await gemmaProvider.generateActivityCards(
+              let (cards, log) = try await gemmaProvider.generateActivityCards(
                 observations: observations, context: context, batchId: batchId)
+              return (self?.attachMeta(cards, providerID: providerID, model: model) ?? cards, log)
             }
           }
         ), fallbackState: fallbackState
@@ -239,26 +302,44 @@ final class LLMService: LLMServicing {
       let endpoint =
         UserDefaults.standard.string(forKey: "llmLocalBaseURL") ?? "http://localhost:11434"
       let provider = makeOllamaProvider(endpoint: endpoint)
+      let model = resolvedModel(for: .ollama)
+      let providerID = "ollama"
       return (
         actions: BatchProviderActions(
           transcribeScreenshots: provider.transcribeScreenshots,
-          generateActivityCards: provider.generateActivityCards
+          generateActivityCards: { [weak self] observations, context, batchId in
+            let (cards, log) = try await provider.generateActivityCards(
+              observations: observations, context: context, batchId: batchId)
+            return (self?.attachMeta(cards, providerID: providerID, model: model) ?? cards, log)
+          }
         ), fallbackState: nil
       )
     case .chatGPTClaude:
       let provider = makeChatCLIProvider(preferredToolOverride: chatToolOverride)
+      let model = resolvedModel(for: .chatGPTClaude)
+      let providerID = "chatgpt_claude"
       return (
         actions: BatchProviderActions(
           transcribeScreenshots: provider.transcribeScreenshots,
-          generateActivityCards: provider.generateActivityCards
+          generateActivityCards: { [weak self] observations, context, batchId in
+            let (cards, log) = try await provider.generateActivityCards(
+              observations: observations, context: context, batchId: batchId)
+            return (self?.attachMeta(cards, providerID: providerID, model: model) ?? cards, log)
+          }
         ), fallbackState: nil
       )
     case .minimax:
       guard let provider = makeMiniMaxProvider() else { throw noProviderError() }
+      let model = resolvedModel(for: .minimax)
+      let providerID = "minimax"
       return (
         actions: BatchProviderActions(
           transcribeScreenshots: provider.transcribeScreenshots,
-          generateActivityCards: provider.generateActivityCards
+          generateActivityCards: { [weak self] observations, context, batchId in
+            let (cards, log) = try await provider.generateActivityCards(
+              observations: observations, context: context, batchId: batchId)
+            return (self?.attachMeta(cards, providerID: providerID, model: model) ?? cards, log)
+          }
         ), fallbackState: nil
       )
     }
@@ -816,7 +897,9 @@ final class LLMService: LLMServicing {
                 detailedSummary: card.detailedSummary,
                 distractions: card.distractions,
                 appSites: card.appSites,
-                isBackupGenerated: isBackupGenerated ? true : nil
+                isBackupGenerated: isBackupGenerated ? true : nil,
+                providerId: card.providerId,
+                modelId: card.modelId
               )
             },
             batchId: batchId

--- a/Dayflow/Dayflow/Core/AI/LLMTypes.swift
+++ b/Dayflow/Dayflow/Core/AI/LLMTypes.swift
@@ -96,6 +96,7 @@ enum LLMProviderType: Codable {
   case dayflowBackend(endpoint: String = "")
   case ollamaLocal(endpoint: String = "http://localhost:11434")
   case chatGPTClaude
+  case minimax
 
   private static let providerDefaultsKey = "llmProviderType"
   private static let selectedProviderDefaultsKey = "selectedLLMProvider"
@@ -134,6 +135,8 @@ enum LLMProviderType: Codable {
       return "ollama"
     case .chatGPTClaude:
       return "chatgpt_claude"
+    case .minimax:
+      return "minimax"
     }
   }
 
@@ -171,6 +174,8 @@ enum LLMProviderType: Codable {
       return .chatGPTClaude
     case "chatgpt_claude":
       return .chatGPTClaude
+    case "minimax":
+      return .minimax
     default:
       return nil
     }
@@ -182,6 +187,7 @@ enum LLMProviderID: String, Codable, CaseIterable {
   case dayflow
   case ollama
   case chatGPTClaude = "chatgpt_claude"
+  case minimax
 
   var analyticsName: String {
     switch self {
@@ -193,6 +199,8 @@ enum LLMProviderID: String, Codable, CaseIterable {
       return "ollama"
     case .chatGPTClaude:
       return "chat_cli"
+    case .minimax:
+      return "minimax"
     }
   }
 
@@ -206,6 +214,8 @@ enum LLMProviderID: String, Codable, CaseIterable {
       return .ollama
     case .chatGPTClaude:
       return .chatGPTClaude
+    case .minimax:
+      return .minimax
     }
   }
 
@@ -219,6 +229,8 @@ enum LLMProviderID: String, Codable, CaseIterable {
       return "local"
     case .chatGPTClaude:
       return chatTool == .claude ? "claude" : "chatgpt"
+    case .minimax:
+      return "minimax"
     }
   }
 }

--- a/Dayflow/Dayflow/Core/AI/LLMTypes.swift
+++ b/Dayflow/Dayflow/Core/AI/LLMTypes.swift
@@ -298,6 +298,39 @@ struct ActivityCardData: Codable {
   let detailedSummary: String
   let distractions: [Distraction]?
   let appSites: AppSites?
+  /// Which Dayflow provider produced this card ("gemini", "minimax",
+  /// "ollama", "chatgpt_claude", or "dayflow"). Optional so older rows
+  /// (saved before this field existed) still decode.
+  let providerId: String?
+  /// Which model the provider used (e.g. "MiniMax-M3", "claude-sonnet-4-5").
+  /// Optional for the same backward-compat reason.
+  let modelId: String?
+
+  init(
+    startTime: String,
+    endTime: String,
+    category: String,
+    subcategory: String,
+    title: String,
+    summary: String,
+    detailedSummary: String,
+    distractions: [Distraction]?,
+    appSites: AppSites?,
+    providerId: String? = nil,
+    modelId: String? = nil
+  ) {
+    self.startTime = startTime
+    self.endTime = endTime
+    self.category = category
+    self.subcategory = subcategory
+    self.title = title
+    self.summary = summary
+    self.detailedSummary = detailedSummary
+    self.distractions = distractions
+    self.appSites = appSites
+    self.providerId = providerId
+    self.modelId = modelId
+  }
 }
 
 // Distraction is defined in StorageManager.swift

--- a/Dayflow/Dayflow/Core/AI/MiniMaxModelPreference.swift
+++ b/Dayflow/Dayflow/Core/AI/MiniMaxModelPreference.swift
@@ -1,0 +1,49 @@
+//
+//  MiniMaxModelPreference.swift
+//  Dayflow
+//
+//  Persisted preference for the active MiniMax model. Mirrors the shape of
+//  `GeminiModelPreference` so the settings UI can drop the same component in.
+//
+
+import Foundation
+
+struct MiniMaxModelPreference: Codable, Equatable {
+  /// Wire-format model id sent in chat completion requests.
+  var modelId: String
+
+  /// Whether the user has selected a non-default model.
+  var hasUserOverride: Bool
+
+  static let `default` = MiniMaxModelPreference(
+    modelId: MiniMaxProvider.defaultModelId,
+    hasUserOverride: false
+  )
+
+  static let storageKey = "minimaxModelPreference"
+
+  static func load(from defaults: UserDefaults = .standard) -> MiniMaxModelPreference {
+    guard let data = defaults.data(forKey: storageKey),
+      let decoded = try? JSONDecoder().decode(MiniMaxModelPreference.self, from: data)
+    else {
+      return .default
+    }
+    return decoded
+  }
+
+  func persist(to defaults: UserDefaults = .standard) {
+    guard let data = try? JSONEncoder().encode(self) else { return }
+    defaults.set(data, forKey: Self.storageKey)
+  }
+
+  mutating func setModelId(_ newValue: String) {
+    let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return }
+    self.modelId = trimmed
+    self.hasUserOverride = (trimmed != MiniMaxProvider.defaultModelId)
+  }
+
+  mutating func reset() {
+    self = .default
+  }
+}

--- a/Dayflow/Dayflow/Core/AI/MiniMaxPromptPreferences.swift
+++ b/Dayflow/Dayflow/Core/AI/MiniMaxPromptPreferences.swift
@@ -1,0 +1,108 @@
+//
+//  MiniMaxPromptPreferences.swift
+//  Dayflow
+//
+//  User-overridable prompt blocks for the MiniMax provider. Defaults are
+//  intentionally aligned with the Ollama prompt defaults so behaviour stays
+//  consistent across providers. Users can customise either block independently.
+//
+
+import Foundation
+
+struct MiniMaxPromptOverrides: Codable, Equatable {
+  var summaryBlock: String?
+  var titleBlock: String?
+
+  var isEmpty: Bool {
+    [summaryBlock, titleBlock].allSatisfy { value in
+      let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+      return trimmed.isEmpty
+    }
+  }
+}
+
+enum MiniMaxPromptPreferences {
+  private static let overridesKey = "minimaxPromptOverrides"
+  private static let store = UserDefaults.standard
+
+  static func load() -> MiniMaxPromptOverrides {
+    guard let data = store.data(forKey: overridesKey) else {
+      return MiniMaxPromptOverrides()
+    }
+    guard let overrides = try? JSONDecoder().decode(MiniMaxPromptOverrides.self, from: data)
+    else {
+      return MiniMaxPromptOverrides()
+    }
+    return overrides
+  }
+
+  static func save(_ overrides: MiniMaxPromptOverrides) {
+    guard let data = try? JSONEncoder().encode(overrides) else { return }
+    store.set(data, forKey: overridesKey)
+  }
+
+  static func reset() {
+    store.removeObject(forKey: overridesKey)
+  }
+}
+
+enum MiniMaxPromptDefaults {
+  static let summaryBlock = """
+      SUMMARY GUIDELINES:
+      - Write in first person without using "I" (like a personal journal entry)
+      - 2-3 sentences maximum
+      - Include specific details (app names, search topics, etc.)
+      - Natural, conversational tone
+
+      GOOD EXAMPLES:
+      "Managed Mac system preferences focusing on software updates and accessibility settings. Browsed Chrome searching for iPhone wireless charging info while
+      checking Twitter and Slack messages."
+
+      "Configured GitHub Actions pipeline for automated testing. Quick Slack check interrupted focus, then back to debugging deployment issues."
+
+      "Researched React performance optimization techniques in Chrome, reading articles about useMemo patterns. Switched between documentation tabs and took notes in
+       Notion about component re-rendering."
+
+      "Updated Xcode project dependencies and resolved build errors in SwiftUI views. Tested app on simulator while responding to client messages about timeline
+      changes."
+
+      "Browsed Instagram and TikTok while listening to Spotify playlist. Responded to personal messages on WhatsApp about weekend plans."
+
+      BAD EXAMPLES:
+      - "The user did various computer activities" (too vague, wrong perspective, never say the user)
+      - "I was working on my computer doing different tasks" (uses "I", not specific)
+      - "Spent time on multiple applications and websites" (generic, no details)
+  """
+
+  static let titleBlock = """
+    Write one activity title for a 15-minute window using ONLY the observations.
+    Rules:
+    - 5-10 words, natural and specific, single line
+    - Choose the dominant activity (most time), not necessarily the first
+    - Ignore brief interruptions (<3 minutes)
+    - Include a second activity only if both take ~5+ minutes
+    - If 3+ unrelated activities appear, output exactly: "Scattered apps and sites"
+    - Prefer proper nouns/topics (Bookface, Claude, League of Legends, Paul Graham, etc.)
+    - Never use: worked on, looked at, handled, various, some, multiple, browsing, browse, multitasking, tabs, brief, quick, short
+    - Do NOT use the word "browsing"; use "scrolling" or "reading" instead
+    - Avoid long lists; no more than one conjunction
+    - Return only the title text (no quotes, no JSON)
+  """
+}
+
+struct MiniMaxPromptSections {
+  let summary: String
+  let title: String
+
+  init(overrides: MiniMaxPromptOverrides) {
+    self.summary = MiniMaxPromptSections.compose(
+      defaultBlock: MiniMaxPromptDefaults.summaryBlock, custom: overrides.summaryBlock)
+    self.title = MiniMaxPromptSections.compose(
+      defaultBlock: MiniMaxPromptDefaults.titleBlock, custom: overrides.titleBlock)
+  }
+
+  private static func compose(defaultBlock: String, custom: String?) -> String {
+    let trimmed = custom?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    return trimmed.isEmpty ? defaultBlock : trimmed
+  }
+}

--- a/Dayflow/Dayflow/Core/AI/MiniMaxProvider+Networking.swift
+++ b/Dayflow/Dayflow/Core/AI/MiniMaxProvider+Networking.swift
@@ -1,0 +1,296 @@
+//
+//  MiniMaxProvider+Networking.swift
+//  Dayflow
+//
+//  HTTP client for the MiniMax OpenAI-compatible API.
+//
+
+import Foundation
+
+extension MiniMaxProvider {
+  struct ChatRequest: Codable {
+    let model: String
+    let messages: [ChatMessage]
+    var temperature: Double = 0.7
+    var max_tokens: Int = 4000
+    var stream: Bool = false
+  }
+
+  struct ChatMessage: Codable {
+    let role: String
+    let content: [MessageContent]
+  }
+
+  struct MessageContent: Codable {
+    let type: String
+    let text: String?
+    let image_url: ImageURL?
+
+    struct ImageURL: Codable {
+      let url: String
+    }
+  }
+
+  struct ChatResponse: Codable {
+    let choices: [Choice]
+
+    struct Choice: Codable {
+      let message: ResponseMessage
+    }
+
+    struct ResponseMessage: Codable {
+      let content: String
+    }
+  }
+
+  // MARK: - Chat completions
+
+  func callChatAPI(
+    _ request: ChatRequest,
+    operation: String,
+    batchId: Int64? = nil,
+    maxRetries: Int = 3
+  ) async throws -> ChatResponse {
+    guard let url = LocalEndpointUtilities.chatCompletionsURL(baseURL: endpoint) else {
+      throw NSError(
+        domain: "MiniMaxProvider", code: 15,
+        userInfo: [NSLocalizedDescriptionKey: "Invalid MiniMax endpoint URL"])
+    }
+
+    let attempts = max(1, maxRetries)
+    var lastError: Error?
+
+    let callGroupId = UUID().uuidString
+    for attempt in 0..<attempts {
+      var ctxForAttempt: LLMCallContext?
+      var didLogFailureThisAttempt = false
+      var didLogTiming = false
+      var apiStart: Date?
+      do {
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuthorizationHeader(to: &urlRequest)
+        urlRequest.httpBody = try JSONEncoder().encode(request)
+        urlRequest.timeoutInterval = 120.0  // M3 can take a while for multimodal batches
+
+        let start = Date()
+        apiStart = start
+        let requestBodyForLogging: Data?
+        if operation == "describe_frame" {
+          requestBodyForLogging = nil
+        } else {
+          requestBodyForLogging = urlRequest.httpBody
+        }
+        let ctx = LLMCallContext(
+          batchId: batchId,
+          callGroupId: callGroupId,
+          attempt: attempt + 1,
+          provider: providerName,
+          model: request.model,
+          operation: operation,
+          requestMethod: urlRequest.httpMethod,
+          requestURL: urlRequest.url,
+          requestHeaders: urlRequest.allHTTPHeaderFields,
+          requestBody: requestBodyForLogging,
+          startedAt: start
+        )
+        ctxForAttempt = ctx
+        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+        let requestDuration = Date().timeIntervalSince(start)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode
+        logCallDuration(operation: operation, duration: requestDuration, status: statusCode)
+        didLogTiming = true
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+          throw NSError(
+            domain: "MiniMaxProvider", code: 4,
+            userInfo: [NSLocalizedDescriptionKey: "Invalid response"])
+        }
+
+        guard httpResponse.statusCode == 200 else {
+          let errorBody = String(data: data, encoding: .utf8) ?? "Unknown error"
+          let responseHeaders: [String: String] = httpResponse.allHeaderFields.reduce(into: [:]) {
+            acc, kv in
+            if let k = kv.key as? String, let v = kv.value as? CustomStringConvertible {
+              acc[k] = v.description
+            }
+          }
+          LLMLogger.logFailure(
+            ctx: ctx,
+            http: LLMHTTPInfo(
+              httpStatus: httpResponse.statusCode,
+              responseHeaders: responseHeaders,
+              responseBody: data),
+            finishedAt: Date(),
+            errorDomain: "MiniMaxProvider",
+            errorCode: httpResponse.statusCode,
+            errorMessage: errorBody
+          )
+          didLogFailureThisAttempt = true
+          throw NSError(
+            domain: "MiniMaxProvider", code: 4,
+            userInfo: [
+              NSLocalizedDescriptionKey:
+                "MiniMax API request failed with status \(httpResponse.statusCode): \(errorBody)"
+            ])
+        }
+
+        do {
+          let chatResponse = try JSONDecoder().decode(ChatResponse.self, from: data)
+          let responseHeaders: [String: String] = httpResponse.allHeaderFields.reduce(into: [:]) {
+            acc, kv in
+            if let k = kv.key as? String, let v = kv.value as? CustomStringConvertible {
+              acc[k] = v.description
+            }
+          }
+          LLMLogger.logSuccess(
+            ctx: ctx,
+            http: LLMHTTPInfo(
+              httpStatus: httpResponse.statusCode,
+              responseHeaders: responseHeaders,
+              responseBody: data),
+            finishedAt: Date()
+          )
+          return chatResponse
+        } catch {
+          let responseHeaders: [String: String] = httpResponse.allHeaderFields.reduce(into: [:]) {
+            acc, kv in
+            if let k = kv.key as? String, let v = kv.value as? CustomStringConvertible {
+              acc[k] = v.description
+            }
+          }
+          LLMLogger.logFailure(
+            ctx: ctx,
+            http: LLMHTTPInfo(
+              httpStatus: httpResponse.statusCode,
+              responseHeaders: responseHeaders,
+              responseBody: data),
+            finishedAt: Date(),
+            errorDomain: (error as NSError).domain,
+            errorCode: (error as NSError).code,
+            errorMessage: (error as NSError).localizedDescription
+          )
+          didLogFailureThisAttempt = true
+          throw error
+        }
+
+      } catch {
+        lastError = error
+        if !didLogTiming, let startedAt = apiStart {
+          let requestDuration = Date().timeIntervalSince(startedAt)
+          logCallDuration(operation: operation, duration: requestDuration, status: nil)
+          didLogTiming = true
+        }
+        print("[MINIMAX] Request failed (attempt \(attempt + 1)/\(attempts)): \(error)")
+
+        if attempt < attempts - 1 {
+          let backoffDelay = pow(2.0, Double(attempt)) * 2.0  // 2s, 4s, 8s
+          try await Task.sleep(nanoseconds: UInt64(backoffDelay * 1_000_000_000))
+        }
+        if !didLogFailureThisAttempt {
+          let fallbackBodyForLogging: Data?
+          if operation == "describe_frame" {
+            fallbackBodyForLogging = nil
+          } else {
+            fallbackBodyForLogging = try? JSONEncoder().encode(request)
+          }
+          let ctx =
+            ctxForAttempt
+            ?? LLMCallContext(
+              batchId: batchId,
+              callGroupId: callGroupId,
+              attempt: attempt + 1,
+              provider: providerName,
+              model: request.model,
+              operation: operation,
+              requestMethod: "POST",
+              requestURL: url,
+              requestHeaders: ["Content-Type": "application/json"],
+              requestBody: fallbackBodyForLogging,
+              startedAt: Date()
+            )
+          LLMLogger.logFailure(
+            ctx: ctx,
+            http: nil,
+            finishedAt: Date(),
+            errorDomain: (error as NSError).domain,
+            errorCode: (error as NSError).code,
+            errorMessage: (error as NSError).localizedDescription
+          )
+          didLogFailureThisAttempt = true
+        }
+      }
+    }
+
+    throw lastError
+      ?? NSError(
+        domain: "MiniMaxProvider", code: 4,
+        userInfo: [NSLocalizedDescriptionKey: "Request failed after \(attempts) attempts"])
+  }
+
+  // MARK: - Text helper
+
+  func callTextAPI(
+    _ prompt: String, operation: String, expectJSON: Bool = false, batchId: Int64? = nil,
+    maxRetries: Int = 3, maxTokens: Int = 4000
+  ) async throws -> String {
+    let systemPrompt =
+      expectJSON
+      ? "You are a helpful assistant. Always respond with valid JSON."
+      : "You are a helpful assistant."
+
+    let request = ChatRequest(
+      model: savedModelId,
+      messages: [
+        ChatMessage(
+          role: "system",
+          content: [MessageContent(type: "text", text: systemPrompt, image_url: nil)]),
+        ChatMessage(
+          role: "user", content: [MessageContent(type: "text", text: prompt, image_url: nil)]),
+      ],
+      temperature: 0.7,
+      max_tokens: maxTokens,
+      stream: false
+    )
+
+    let response = try await callChatAPI(
+      request, operation: operation, batchId: batchId, maxRetries: maxRetries)
+    let raw = response.choices.first?.message.content ?? ""
+    return MiniMaxReasoning.stripThinkTags(in: raw)
+  }
+
+  private func applyAuthorizationHeader(to request: inout URLRequest) {
+    if let key = apiKey {
+      request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+    }
+  }
+}
+
+// MARK: - Text Generation
+
+extension MiniMaxProvider {
+  func generateText(prompt: String, maxTokens: Int = 4000) async throws
+    -> (text: String, log: LLMCall)
+  {
+    let callStart = Date()
+
+    let response = try await callTextAPI(
+      prompt,
+      operation: "generate_text",
+      expectJSON: false,
+      batchId: nil,
+      maxRetries: 3,
+      maxTokens: maxTokens
+    )
+
+    let log = LLMCall(
+      timestamp: callStart,
+      latency: Date().timeIntervalSince(callStart),
+      input: prompt,
+      output: response
+    )
+
+    return (response.trimmingCharacters(in: .whitespacesAndNewlines), log)
+  }
+}

--- a/Dayflow/Dayflow/Core/AI/MiniMaxProvider+Reasoning.swift
+++ b/Dayflow/Dayflow/Core/AI/MiniMaxProvider+Reasoning.swift
@@ -1,0 +1,68 @@
+//
+//  MiniMaxProvider+Reasoning.swift
+//  Dayflow
+//
+//  MiniMax M3 emits `<think>...</think>` reasoning blocks inside the
+//  `content` field of chat completions responses. We strip those before
+//  parsing/returning the answer so the downstream JSON parsers and UI
+//  text consumers don't have to care about them.
+//
+
+import Foundation
+
+enum MiniMaxReasoning {
+  /// Removes one or more `<think>...</think>` blocks from the model output.
+  /// Handles the case where reasoning is not closed (defensive).
+  static func stripThinkTags(in text: String) -> String {
+    guard !text.isEmpty else { return text }
+
+    var result = ""
+    var remaining = text
+
+    while let openRange = remaining.range(of: "<think>") {
+      // Append everything before the open tag.
+      result += String(remaining[remaining.startIndex..<openRange.lowerBound])
+      let afterOpen = remaining[openRange.upperBound...]
+
+      if let closeRange = afterOpen.range(of: "</think>") {
+        // Skip the entire reasoning block.
+        remaining = String(afterOpen[closeRange.upperBound...])
+      } else {
+        // Unterminated think block — drop the rest.
+        remaining = ""
+        break
+      }
+    }
+
+    result += remaining
+    return result.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  /// If the response contains reasoning, return it separately from the answer.
+  /// Useful for logging or surfacing a "thinking" indicator in the UI.
+  static func split(_ text: String) -> (reasoning: String, answer: String) {
+    guard !text.isEmpty else { return ("", "") }
+    var reasoningPieces: [String] = []
+    var remaining = text
+    var answer = ""
+
+    while let openRange = remaining.range(of: "<think>") {
+      answer += String(remaining[remaining.startIndex..<openRange.lowerBound])
+      let afterOpen = remaining[openRange.upperBound...]
+      if let closeRange = afterOpen.range(of: "</think>") {
+        reasoningPieces.append(String(afterOpen[afterOpen.startIndex..<closeRange.lowerBound]))
+        remaining = String(afterOpen[closeRange.upperBound...])
+      } else {
+        reasoningPieces.append(String(afterOpen))
+        remaining = ""
+        break
+      }
+    }
+    answer += remaining
+
+    return (
+      reasoning: reasoningPieces.joined(separator: "\n\n").trimmingCharacters(in: .whitespacesAndNewlines),
+      answer: answer.trimmingCharacters(in: .whitespacesAndNewlines)
+    )
+  }
+}

--- a/Dayflow/Dayflow/Core/AI/MiniMaxProvider+Summaries.swift
+++ b/Dayflow/Dayflow/Core/AI/MiniMaxProvider+Summaries.swift
@@ -1,0 +1,481 @@
+//
+//  MiniMaxProvider+Summaries.swift
+//  Dayflow
+//
+//  Title / summary / merge-card prompt execution for the MiniMax provider.
+//  Logic mirrors OllamaProvider+Summaries.swift with a few adaptations:
+//  - uses `MiniMaxPromptSections` so users can override prompts independently
+//  - wraps responses in `MiniMaxReasoning.stripThinkTags` defensively
+//
+
+import Foundation
+
+extension MiniMaxProvider {
+  struct TitleSummaryResponse: Codable {
+    let reasoning: String
+    let title: String
+    let summary: String
+    let category: String
+    let appSites: AppSites?
+  }
+
+  private struct SummaryResponse: Codable {
+    let reasoning: String
+    let summary: String
+    let category: String
+    let appSites: AppSitesResponse?
+
+    struct AppSitesResponse: Codable {
+      let primary: String?
+      let secondary: String?
+    }
+
+    enum CodingKeys: String, CodingKey {
+      case reasoning
+      case summary
+      case category
+      case appSites = "app_sites"
+    }
+  }
+
+  private struct TitleResponse: Codable {
+    let reasoning: String
+    let title: String
+  }
+
+  private struct MergeDecision: Codable {
+    let reason: String
+    let combine: Bool
+  }
+
+  private func normalizeTitleText(_ response: String) -> String {
+    let trimmed = response.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return "" }
+
+    let firstLine = trimmed.split(whereSeparator: \.isNewline).first.map(String.init) ?? trimmed
+    var result = firstLine.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    if result.hasPrefix("\""), result.hasSuffix("\""), result.count >= 2 {
+      result = String(result.dropFirst().dropLast())
+    }
+
+    let lowercased = result.lowercased()
+    if lowercased.hasPrefix("title:") {
+      let dropped = String(result.dropFirst("title:".count))
+      result = dropped.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    return result
+  }
+
+  private func buildAppSites(from response: SummaryResponse.AppSitesResponse?) -> AppSites? {
+    guard let response else { return nil }
+    let primary = response.primary?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let secondary = response.secondary?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    let cleanedPrimary = primary?.isEmpty == false ? primary : nil
+    let cleanedSecondary = secondary?.isEmpty == false ? secondary : nil
+
+    if cleanedPrimary == nil && cleanedSecondary == nil {
+      return nil
+    }
+
+    return AppSites(primary: cleanedPrimary, secondary: cleanedSecondary)
+  }
+
+  private func generateSummary(
+    observations: [Observation], categories: [LLMCategoryDescriptor], batchId: Int64?
+  ) async throws -> (SummaryResponse, String) {
+    let observationLines: [String] = observations.map { obs in
+      let startTime = formatTimestampForPrompt(obs.startTs)
+      let endTime = formatTimestampForPrompt(obs.endTs)
+      return "[\(startTime) - \(endTime)]: \(obs.observation)"
+    }
+    let observationsText: String = stripUserReferences(observationLines.joined(separator: "\n\n"))
+
+    let descriptorList = categories.isEmpty ? CategoryStore.descriptorsForLLM() : categories
+    let categoryLines: [String] = descriptorList.enumerated().map { index, descriptor in
+      var description =
+        descriptor.description?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+      if descriptor.isIdle && description.isEmpty {
+        description = "Use when the user is idle for most of the period."
+      }
+      let dashDescription = description.isEmpty ? "" : " — \(description)"
+      return "- \"\(descriptor.name)\"\(dashDescription)"
+    }
+    let categoriesSection: String = categoryLines.joined(separator: "\n")
+
+    let allowedValues: String =
+      descriptorList
+      .map { "\"\($0.name)\"" }
+      .joined(separator: ", ")
+
+    let promptSections = MiniMaxPromptSections(overrides: MiniMaxPromptPreferences.load())
+
+    let languageBlock =
+      LLMOutputLanguagePreferences.languageInstruction(forJSON: true)
+      .map { "\n\n\($0)" } ?? ""
+
+    let basePrompt = """
+      You are analyzing someone's computer activity from the last 15 minutes.
+
+      Activity periods:
+      \(observationsText)
+
+        Create a summary that captures what happened during this time period.
+
+      \(promptSections.summary)
+
+      CATEGORIES:
+      Choose exactly one:
+      \(categoriesSection)
+
+      APP SITES (Website Logos)
+      Identify the main app or website used for this period. Output the canonical DOMAIN, not the app name.
+      - primary: canonical domain of the main app/website used.
+      - secondary: another meaningful app used, if relevant.
+      - Format: lower-case, no protocol, no query or fragments.
+      - Use product subdomains/paths when canonical (e.g., docs.google.com).
+      - If you cannot determine a secondary, omit it.
+      - Do not invent brands; rely on evidence from observations.
+
+        REASONING:
+        Explain your thinking process:
+        1. What were the main activities and how much time was spent on each?
+        2. Was this primarily work-related, personal, or brief distractions?
+        3. Which category best fits based on the MAJORITY of time and focus?
+        4. How did you structure the summary to capture the most important activities?
+
+      \(languageBlock)
+
+      Return JSON:
+      {
+        "reasoning": "Your step-by-step thinking process",
+        "summary": "Your 2-3 sentence summary",
+        "category": "\(allowedValues)",
+        "app_sites": {"primary": "domain.com", "secondary": "domain.com"}
+      }
+      """
+
+    let maxAttempts = 3
+    var prompt = basePrompt
+    var lastError: Error?
+
+    for attempt in 1...maxAttempts {
+      do {
+        let response = try await callTextAPI(
+          prompt, operation: "generate_summary", expectJSON: true, batchId: batchId)
+
+        guard let data = response.data(using: .utf8) else {
+          throw NSError(
+            domain: "MiniMaxProvider", code: 12,
+            userInfo: [NSLocalizedDescriptionKey: "Failed to parse summary response"])
+        }
+
+        let result = try parseJSONResponse(SummaryResponse.self, from: data)
+        return (result, response)
+      } catch {
+        lastError = error
+        if attempt == maxAttempts { throw error }
+
+        print("[MINIMAX] ⚠️ generateSummary attempt \(attempt) failed: \(error.localizedDescription)")
+
+        prompt =
+          basePrompt + """
+
+
+            PREVIOUS ATTEMPT FAILED — The response was invalid (error: \(error.localizedDescription)).
+            Respond with ONLY the JSON object described above. Ensure it contains "reasoning", "summary", "category", and "app_sites" fields.
+            """
+      }
+    }
+
+    throw lastError
+      ?? NSError(
+        domain: "MiniMaxProvider", code: 12,
+        userInfo: [NSLocalizedDescriptionKey: "Failed to generate summary after multiple attempts"])
+  }
+
+  private func generateTitle(observations: [Observation], batchId: Int64?) async throws -> (
+    TitleResponse, String
+  ) {
+    let promptSections = MiniMaxPromptSections(overrides: MiniMaxPromptPreferences.load())
+    let languageBlock =
+      LLMOutputLanguagePreferences.languageInstruction(forJSON: false)
+      .map { "\n\n\($0)" } ?? ""
+    let observationsText =
+      observations
+      .map { $0.observation.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+      .map { "- \($0)" }
+      .joined(separator: "\n")
+
+    let basePrompt = """
+      \(promptSections.title)
+      \(languageBlock)
+
+      OBSERVATIONS:
+      \(observationsText)
+      """
+
+    let maxAttempts = 3
+    var prompt = basePrompt
+    var lastError: Error?
+
+    for attempt in 1...maxAttempts {
+      do {
+        let response = try await callTextAPI(
+          prompt, operation: "generate_title", expectJSON: false, batchId: batchId)
+        let title = normalizeTitleText(response)
+        guard !title.isEmpty else {
+          throw NSError(
+            domain: "MiniMaxProvider", code: 12,
+            userInfo: [NSLocalizedDescriptionKey: "Empty title response"])
+        }
+        let result = TitleResponse(reasoning: "Generated from observations.", title: title)
+        return (result, response)
+      } catch {
+        lastError = error
+        if attempt == maxAttempts { throw error }
+        print("[MINIMAX] ⚠️ generateTitle attempt \(attempt) failed: \(error.localizedDescription)")
+        prompt =
+          basePrompt + """
+
+
+            PREVIOUS ATTEMPT FAILED — The response was invalid (error: \(error.localizedDescription)).
+            Respond with ONLY the title text on a single line. Do not include JSON or quotes.
+            """
+      }
+    }
+
+    throw lastError
+      ?? NSError(
+        domain: "MiniMaxProvider", code: 12,
+        userInfo: [NSLocalizedDescriptionKey: "Failed to generate title after multiple attempts"])
+  }
+
+  func generateTitleAndSummary(
+    observations: [Observation], categories: [LLMCategoryDescriptor], batchId: Int64?
+  ) async throws -> (TitleSummaryResponse, String) {
+    let (summaryResult, summaryLog) = try await generateSummary(
+      observations: observations,
+      categories: categories,
+      batchId: batchId
+    )
+
+    let (titleResult, titleLog) = try await generateTitle(
+      observations: observations, batchId: batchId)
+
+    let appSites = buildAppSites(from: summaryResult.appSites)
+
+    let combinedResult = TitleSummaryResponse(
+      reasoning: "Summary: \(summaryResult.reasoning) | Title: \(titleResult.reasoning)",
+      title: titleResult.title,
+      summary: summaryResult.summary,
+      category: summaryResult.category,
+      appSites: appSites
+    )
+
+    let combinedLog =
+      "=== SUMMARY GENERATION ===\n\(summaryLog)\n\n=== TITLE GENERATION ===\n\(titleLog)"
+
+    return (combinedResult, combinedLog)
+  }
+
+  func checkShouldMerge(
+    previousCard: ActivityCardData, newCard: ActivityCardData, batchId: Int64?
+  ) async throws -> (Bool, String) {
+    let basePrompt = """
+      Decide if two consecutive activity cards should be merged.
+
+      Previous activity (\(previousCard.startTime) - \(previousCard.endTime)):
+      Title: \(previousCard.title)
+      Summary: \(previousCard.summary)
+
+      New activity (\(newCard.startTime) - \(newCard.endTime)):
+      Title: \(newCard.title)
+      Summary: \(newCard.summary)
+
+      Merge ONLY if they clearly describe the same ongoing task or intent.
+      - Tool/app switches are allowed if they support the same goal (e.g., doc writing + research).
+      - Do NOT merge if there’s a context switch to a different intent (social feed, chat, video, gaming, email, shopping, unrelated reading).
+      - If unsure, do NOT merge.
+
+      Return JSON only:
+      {"combine": true/false, "reason": "1 short sentence explaining the decision"}
+
+      EXAMPLES (5):
+
+      1) MERGE
+      Prev: "Drafted onboarding doc in Google Docs. Looked up API details in the Stripe docs."
+      New:  "Continued the onboarding doc, then cross-checked examples in Stripe docs."
+      → {"combine": true, "reason": "Same intent: onboarding doc + supporting research."}
+
+      2) MERGE
+      Prev: "Analyzed retention curves in Claude. Adjusted questions for clarity."
+      New:  "Kept refining retention metrics in Claude and Notion."
+      → {"combine": true, "reason": "Same intent: retention analysis across tools."}
+
+      3) MERGE
+      Prev: "Fixed React auth bug in VS Code. Ran local tests."
+      New:  "Validated the auth fix in Postman and added notes to the PR."
+      → {"combine": true, "reason": "Same task: auth fix and verification."}
+
+      4) DON'T MERGE
+      Prev: "Reviewed VC blog post on trohan.com."
+      New:  "Watched League of Legends stream and chatted on Messenger."
+      → {"combine": false, "reason": "Different intent: research vs entertainment/chat."}
+
+      5) DON'T MERGE
+      Prev: "Drafted email reply about product launch."
+      New:  "Scrolled X.com and watched a YouTube clip."
+      → {"combine": false, "reason": "Context switch to social/video."}
+      """
+
+    let maxAttempts = 3
+    var prompt = basePrompt
+    var lastError: Error?
+
+    for attempt in 1...maxAttempts {
+      do {
+        let response = try await callTextAPI(
+          prompt, operation: "evaluate_card_merge", expectJSON: true, batchId: batchId)
+
+        guard let data = response.data(using: String.Encoding.utf8) else {
+          throw NSError(
+            domain: "MiniMaxProvider", code: 13,
+            userInfo: [NSLocalizedDescriptionKey: "Failed to parse merge decision"])
+        }
+
+        let decision = try parseJSONResponse(MergeDecision.self, from: data)
+        return (decision.combine, response)
+      } catch {
+        lastError = error
+        if attempt == maxAttempts { throw error }
+        print("[MINIMAX] ⚠️ evaluate_card_merge attempt \(attempt) failed: \(error.localizedDescription)")
+        prompt =
+          basePrompt + """
+
+
+            PREVIOUS ATTEMPT FAILED — The response was invalid (error: \(error.localizedDescription)).
+            Return ONLY the JSON object described above with "reason" and "combine" fields.
+            """
+      }
+    }
+
+    throw lastError
+      ?? NSError(
+        domain: "MiniMaxProvider", code: 13,
+        userInfo: [NSLocalizedDescriptionKey: "Failed to evaluate merge decision after multiple attempts"])
+  }
+
+  func mergeTwoCards(
+    previousCard: ActivityCardData, newCard: ActivityCardData, batchId: Int64?
+  ) async throws -> (ActivityCardData, String) {
+    let basePrompt = """
+      Create a single activity card that covers both time periods.
+
+      Activity 1 (\(previousCard.startTime) - \(previousCard.endTime)):
+      Title: \(previousCard.title)
+      Summary: \(previousCard.summary)
+
+      Activity 2 (\(newCard.startTime) - \(newCard.endTime)):
+      Title: \(newCard.title)
+      Summary: \(newCard.summary)
+
+      Create a unified title and summary that covers the entire period from \(previousCard.startTime) to \(newCard.endTime).
+      Title rules (use ONLY the titles and summaries above):
+      - 5-10 words, natural and specific, single line
+      - Choose the dominant activity (most time), not necessarily the first
+      - Ignore brief interruptions (<3 minutes) mentioned in the summaries
+      - Include a second activity only if both take ~5+ minutes
+      - If 3+ unrelated activities appear, output exactly: "Scattered apps and sites"
+      - Prefer proper nouns/topics (Bookface, Claude, League of Legends, Paul Graham, etc.)
+      - Never use: worked on, looked at, handled, various, some, multiple, browsing, browse, multitasking, tabs, brief, quick, short
+      - Do NOT use the word "browsing"; use "scrolling" or "reading" instead
+      - Avoid long lists; no more than one conjunction
+      - In the JSON below, the "title" field must contain only the title text (no extra labels or quotes)
+      Summary: Two sentences max, first-person perspective without using the word I. Retell how the work flowed from the first card into the second with concrete verbs (debugged, reviewed, watched) and name the stand-out tools/topics once each. Skip laundry lists, filler like “various tasks,” and bullet points.
+      Avoid the words social, media, platform, platforms, interaction, interactions, various, engaged, blend, activity, activities.
+      Do not refer to the user; write from the user’s perspective.
+
+      \(LLMOutputLanguagePreferences.languageInstruction(forJSON: true) ?? "")
+
+        GOOD EXAMPLES:
+        Card 1: Customer interviews wrap-up + Card 2: Insights deck synthesis
+        Merged Title: Shaped customer story for insights deck
+        Merged Summary: Logged interview quotes into Airtable. Highlighted the strongest themes and molded them into the insights deck outline.
+
+        Card 1: QA-ing mobile release + Card 2: Answering support tickets
+        Merged Title: Balanced mobile QA while clearing support
+        Merged Summary: Ran through the iOS smoke checklist in TestFlight. Hopped into Help Scout to close the urgent tickets.
+
+        BAD EXAMPLES:
+        ✗ Title: Coding, gaming, and Swift fixes with AI tools and Dayflow (comma list trying to cover everything)
+        ✗ Title: Busy afternoon session (too vague)
+        ✗ Summary: Worked on several things across platforms (generic, missing specifics)
+        ✗ Summary that omits a named site/app/topic from the inputs
+        ✗ Summary longer than three sentences or formatted as bullet points
+
+      Return JSON:
+      {
+        "title": "Merged title",
+        "summary": "Merged summary"
+      }
+      """
+
+    let maxAttempts = 3
+    var prompt = basePrompt
+    var lastError: Error?
+
+    struct MergedContent: Codable {
+      let title: String
+      let summary: String
+    }
+
+    for attempt in 1...maxAttempts {
+      do {
+        let response = try await callTextAPI(
+          prompt, operation: "merge_cards", expectJSON: true, batchId: batchId)
+
+        guard let data = response.data(using: .utf8) else {
+          throw NSError(
+            domain: "MiniMaxProvider", code: 14,
+            userInfo: [NSLocalizedDescriptionKey: "Failed to parse merged card"])
+        }
+
+        let merged = try parseJSONResponse(MergedContent.self, from: data)
+
+        let mergedCard = ActivityCardData(
+          startTime: previousCard.startTime,
+          endTime: newCard.endTime,
+          category: previousCard.category,
+          subcategory: previousCard.subcategory,
+          title: merged.title,
+          summary: merged.summary,
+          detailedSummary: previousCard.detailedSummary,
+          distractions: previousCard.distractions,
+          appSites: previousCard.appSites ?? newCard.appSites
+        )
+
+        return (mergedCard, response)
+      } catch {
+        lastError = error
+        if attempt == maxAttempts { throw error }
+        print("[MINIMAX] ⚠️ merge_cards attempt \(attempt) failed: \(error.localizedDescription)")
+        prompt =
+          basePrompt + """
+
+
+            PREVIOUS ATTEMPT FAILED — The response was invalid (error: \(error.localizedDescription)).
+            Respond with ONLY the JSON object described above containing merged "title" and "summary" fields.
+            """
+      }
+    }
+
+    throw lastError
+      ?? NSError(
+        domain: "MiniMaxProvider", code: 14,
+        userInfo: [NSLocalizedDescriptionKey: "Failed to merge cards after multiple attempts"])
+  }
+}

--- a/Dayflow/Dayflow/Core/AI/MiniMaxProvider+Transcription.swift
+++ b/Dayflow/Dayflow/Core/AI/MiniMaxProvider+Transcription.swift
@@ -1,0 +1,507 @@
+//
+//  MiniMaxProvider+Transcription.swift
+//  Dayflow
+//
+//  Screenshot / frame transcription for the MiniMax provider.
+//  Logic mirrors OllamaProvider+Transcription.swift, adapted for MiniMax M3.
+//
+
+import AppKit
+import Foundation
+
+extension MiniMaxProvider {
+  fileprivate struct FrameData {
+    let image: Data  // Base64 encoded image
+    let timestamp: TimeInterval  // Seconds from batch start
+  }
+
+  fileprivate struct VideoSegment: Codable {
+    let startTimestamp: String  // MM:SS format
+    let endTimestamp: String  // MM:SS format
+    let description: String
+  }
+
+  fileprivate struct SegmentGroupingResponse: Codable {
+    let reasoning: String
+    let segments: [VideoSegment]
+  }
+
+  fileprivate struct SegmentCoverageError: LocalizedError {
+    let coverageRatio: Double
+    let durationString: String
+
+    var percentage: Int { max(0, min(100, Int(coverageRatio * 100))) }
+
+    var errorDescription: String? {
+      "Segments only cover \(percentage)% of video (expected >80%). Video is \(durationString) long."
+    }
+  }
+
+  fileprivate func parseVideoTimestamp(_ timestamp: String) -> Int {
+    let components = timestamp.components(separatedBy: ":")
+    if components.count == 3 {
+      guard let h = Int(components[0]), let m = Int(components[1]), let s = Int(components[2]) else {
+        return 0
+      }
+      return h * 3600 + m * 60 + s
+    } else if components.count == 2 {
+      guard let m = Int(components[0]), let s = Int(components[1]) else { return 0 }
+      return m * 60 + s
+    }
+    return 0
+  }
+
+  fileprivate func getSimpleFrameDescription(_ frame: FrameData, batchId: Int64?) async -> String? {
+    let prompt = """
+      Describe what you see on this computer screen in 1-2 sentences.
+      Focus on: what application/site is open, what the user is doing, and any relevant details visible.
+      Be specific and factual.
+
+      GOOD EXAMPLES:
+      ✓ "VS Code open with index.js file, writing a React component for user authentication."
+      ✓ "Gmail compose window writing email to client@company.com about project timeline."
+      ✓ "Slack conversation in #engineering channel discussing API rate limiting issues."
+
+      BAD EXAMPLES:
+      ✗ "User is coding" (too vague)
+      ✗ "Looking at a website" (doesn't identify which site)
+      ✗ "Working on computer" (completely non-specific)
+      """
+
+    guard let base64String = String(data: frame.image, encoding: .utf8) else {
+      print("[MINIMAX] ⚠️ Failed to decode frame image — skipping frame")
+      return nil
+    }
+
+    let content: [MessageContent] = [
+      MessageContent(type: "text", text: prompt, image_url: nil),
+      MessageContent(
+        type: "image_url", text: nil,
+        image_url: MessageContent.ImageURL(url: "data:image/jpeg;base64,\(base64String)")),
+    ]
+
+    let request = ChatRequest(
+      model: savedModelId,
+      messages: [ChatMessage(role: "user", content: content)]
+    )
+
+    do {
+      let response = try await callChatAPI(
+        request, operation: "describe_frame", batchId: batchId, maxRetries: 1)
+      let raw = response.choices.first?.message.content ?? ""
+      return MiniMaxReasoning.stripThinkTags(in: raw)
+    } catch {
+      print(
+        "[MINIMAX] ⚠️ describe_frame failed at \(frame.timestamp)s — skipping frame: \(error.localizedDescription)"
+      )
+      return nil
+    }
+  }
+
+  fileprivate func decodeSegmentResponse(_ response: String) throws -> (
+    segments: [VideoSegment], reasoning: String
+  ) {
+    guard let rawData = response.data(using: .utf8) else {
+      throw NSError(
+        domain: "MiniMaxProvider", code: 8,
+        userInfo: [NSLocalizedDescriptionKey: "Failed to parse segment response"])
+    }
+
+    if let object = try? parseJSONResponse(SegmentGroupingResponse.self, from: rawData) {
+      return (object.segments, object.reasoning)
+    }
+    if let array = try? parseJSONResponse([VideoSegment].self, from: rawData) {
+      return (array, "")
+    }
+    if let start = response.firstIndex(of: "{"),
+      let end = response.lastIndex(of: "}")
+    {
+      let substring = response[start...end]
+      if let data = substring.data(using: .utf8),
+        let object = try? parseJSONResponse(SegmentGroupingResponse.self, from: data)
+      {
+        return (object.segments, object.reasoning)
+      }
+    }
+    if let start = response.firstIndex(of: "["),
+      let end = response.lastIndex(of: "]")
+    {
+      let substring = response[start...end]
+      if let data = substring.data(using: .utf8),
+        let array = try? parseJSONResponse([VideoSegment].self, from: data)
+      {
+        return (array, "")
+      }
+    }
+    throw NSError(
+      domain: "MiniMaxProvider", code: 9,
+      userInfo: [NSLocalizedDescriptionKey: "Could not parse segment response as JSON"])
+  }
+
+  fileprivate func convertSegmentsToObservations(
+    _ segments: [VideoSegment],
+    batchStartTime: Date,
+    videoDuration: TimeInterval,
+    durationString: String
+  ) throws -> (observations: [Observation], coverage: Double) {
+    var observations: [Observation] = []
+    var totalDuration: TimeInterval = 0
+    var lastEndTime: TimeInterval?
+
+    for (index, segment) in segments.enumerated() {
+      let startSeconds = TimeInterval(parseVideoTimestamp(segment.startTimestamp))
+      let endSeconds = TimeInterval(parseVideoTimestamp(segment.endTimestamp))
+
+      let tolerance: TimeInterval = 30.0
+      if startSeconds < -tolerance || endSeconds > videoDuration + tolerance {
+        print(
+          "[MINIMAX] ❌ Segment \(index + 1) exceeds video duration: \(segment.startTimestamp)-\(segment.endTimestamp) (video is \(durationString))"
+        )
+        continue
+      }
+
+      let clampedDuration = max(0, endSeconds - startSeconds)
+      totalDuration += clampedDuration
+      lastEndTime = endSeconds
+
+      let startDate = batchStartTime.addingTimeInterval(startSeconds)
+      let endDate = batchStartTime.addingTimeInterval(endSeconds)
+
+      observations.append(
+        Observation(
+          id: nil,
+          batchId: 0,
+          startTs: Int(startDate.timeIntervalSince1970),
+          endTs: Int(endDate.timeIntervalSince1970),
+          observation: segment.description,
+          metadata: nil,
+          llmModel: savedModelId,
+          createdAt: Date()
+        )
+      )
+    }
+
+    if observations.isEmpty {
+      throw NSError(
+        domain: "MiniMaxProvider", code: 11,
+        userInfo: [
+          NSLocalizedDescriptionKey:
+            "Screenshots failed to process - check MiniMax API configuration or report a bug."
+        ])
+    }
+
+    if observations.count > 5 {
+      throw NSError(
+        domain: "MiniMaxProvider", code: 13,
+        userInfo: [
+          NSLocalizedDescriptionKey:
+            "Generated \(observations.count) observations, but expected 2-5. The LLM must follow the instruction to create EXACTLY 2-5 segments."
+        ])
+    }
+
+    let coverage = videoDuration > 0 ? totalDuration / videoDuration : 0
+    return (observations, coverage)
+  }
+
+  fileprivate func observationsFromFrames(
+    _ frameDescriptions: [(timestamp: TimeInterval, description: String)],
+    batchStartTime: Date,
+    videoDuration: TimeInterval
+  ) throws -> [Observation] {
+    guard !frameDescriptions.isEmpty else {
+      throw NSError(
+        domain: "MiniMaxProvider",
+        code: 11,
+        userInfo: [
+          NSLocalizedDescriptionKey:
+            "It looks like the MiniMax API is not responding. Please check your API key and network connection in settings."
+        ]
+      )
+    }
+
+    let sortedFrames = frameDescriptions.sorted { $0.timestamp < $1.timestamp }
+    let durationCap = videoDuration > 0 ? videoDuration : nil
+    var observations: [Observation] = []
+
+    for (index, frame) in sortedFrames.enumerated() {
+      let startSeconds = max(0, frame.timestamp)
+      var endSeconds = startSeconds + screenshotInterval
+
+      if index + 1 < sortedFrames.count {
+        endSeconds = min(endSeconds, sortedFrames[index + 1].timestamp)
+      }
+      if let cap = durationCap {
+        endSeconds = min(endSeconds, cap)
+      }
+      if endSeconds <= startSeconds {
+        endSeconds = startSeconds + max(1, screenshotInterval)
+        if let cap = durationCap { endSeconds = min(endSeconds, cap) }
+      }
+
+      let startDate = batchStartTime.addingTimeInterval(startSeconds)
+      let endDate = batchStartTime.addingTimeInterval(endSeconds)
+
+      observations.append(
+        Observation(
+          id: nil,
+          batchId: 0,
+          startTs: Int(startDate.timeIntervalSince1970),
+          endTs: Int(endDate.timeIntervalSince1970),
+          observation: frame.description,
+          metadata: nil,
+          llmModel: nil,
+          createdAt: Date()
+        )
+      )
+    }
+    return observations
+  }
+
+  fileprivate func mergeFrameDescriptions(
+    _ frameDescriptions: [(timestamp: TimeInterval, description: String)],
+    batchStartTime: Date,
+    videoDuration: TimeInterval,
+    batchId: Int64?
+  ) async throws -> [Observation] {
+    var formattedDescriptions = ""
+    for frame in frameDescriptions {
+      let minutes = Int(frame.timestamp) / 60
+      let seconds = Int(frame.timestamp) % 60
+      let timeStr = String(format: "%02d:%02d", minutes, seconds)
+      formattedDescriptions += "[\(timeStr)] \(frame.description)\n"
+    }
+
+    let durationMinutes = Int(videoDuration / 60)
+    let durationSeconds = Int(videoDuration.truncatingRemainder(dividingBy: 60))
+    let durationString = String(format: "%02d:%02d", durationMinutes, durationSeconds)
+
+    let basePrompt = """
+      You have \(frameDescriptions.count) snapshots from a \(durationString) screen recording.
+
+      CRITICAL TASK: Group these snapshots into EXACTLY 2-5 coherent segments that collectively explain \(durationString) of activity. Brief interruptions (< 2 minutes) should be absorbed into the surrounding segment.
+
+      Here are the snapshots (timestamp → description):
+      \(formattedDescriptions)
+
+      Respond with a JSON object using this exact shape:
+      {
+        "reasoning": "Use this space to think through how you're going to construct the segments",
+        "segments": [
+          {
+            "startTimestamp": "MM:SS",
+            "endTimestamp": "MM:SS",
+            "description": "Natural language summary of what happened"
+          }
+        ]
+      }
+
+      HARD REQUIREMENTS:
+      - "segments" MUST contain between 2 and 5 items.
+      - Every timestamp must stay within 00:00 and \(durationString).
+      - Segments should cover at least 80% of the video (ideally 100%) without inventing events.
+      - Merge small gaps instead of creating tiny standalone segments.
+      - Never output additional text outside the JSON object.
+      """
+
+    let maxAttempts = 2
+    var prompt = basePrompt
+    var lastError: Error?
+
+    for attempt in 1...maxAttempts {
+      do {
+        let response = try await callTextAPI(
+          prompt, operation: "segment_video_activity", expectJSON: true, batchId: batchId)
+        let (segments, _) = try decodeSegmentResponse(response)
+        let (observations, coverage) = try convertSegmentsToObservations(
+          segments,
+          batchStartTime: batchStartTime,
+          videoDuration: videoDuration,
+          durationString: durationString
+        )
+
+        if coverage < 0.8 {
+          throw SegmentCoverageError(coverageRatio: coverage, durationString: durationString)
+        }
+        return observations
+      } catch let coverageError as SegmentCoverageError {
+        lastError = coverageError
+        if attempt == maxAttempts {
+          print("[MINIMAX] ❌ segment_video_activity retries exhausted (coverage)")
+          return try observationsFromFrames(
+            frameDescriptions,
+            batchStartTime: batchStartTime,
+            videoDuration: videoDuration
+          )
+        }
+        prompt =
+          basePrompt + """
+
+
+            PREVIOUS ATTEMPT FAILED — Your segments only covered \(coverageError.percentage)% of the \(durationString) video.
+            Merge adjacent snapshots or extend segment boundaries so the segments cover at least 80% of the runtime without inventing events.
+            """
+      } catch {
+        lastError = error
+        if attempt == maxAttempts {
+          print("[MINIMAX] ❌ segment_video_activity retries exhausted (error: \(error.localizedDescription))")
+          return try observationsFromFrames(
+            frameDescriptions,
+            batchStartTime: batchStartTime,
+            videoDuration: videoDuration
+          )
+        }
+        prompt =
+          basePrompt + """
+
+
+            PREVIOUS ATTEMPT FAILED — The response was invalid (error: \(error.localizedDescription)).
+            Respond with ONLY the JSON object described above. Ensure it contains a "reasoning" string and a "segments" array with 2-5 items covering at least 80% of the video.
+            """
+      }
+    }
+
+    throw lastError
+      ?? NSError(
+        domain: "MiniMaxProvider", code: 9,
+        userInfo: [NSLocalizedDescriptionKey: "Failed to generate merged observations after multiple attempts"])
+  }
+}
+
+// MARK: - Public transcription entry point
+
+extension MiniMaxProvider {
+  /// Transcribe observations from screenshots.
+  func transcribeScreenshots(
+    _ screenshots: [Screenshot],
+    batchStartTime: Date,
+    batchId: Int64?
+  ) async throws -> (observations: [Observation], log: LLMCall) {
+    guard !screenshots.isEmpty else {
+      throw NSError(
+        domain: "MiniMaxProvider", code: 12,
+        userInfo: [NSLocalizedDescriptionKey: "No screenshots to transcribe"])
+    }
+
+    let callStart = Date()
+    let sortedScreenshots = screenshots.sorted { $0.capturedAt < $1.capturedAt }
+
+    // Sample ~15 evenly spaced screenshots to keep the request bounded.
+    let targetSamples = 15
+    let strideAmount = max(1, sortedScreenshots.count / targetSamples)
+    let sampledScreenshots = Swift.stride(from: 0, to: sortedScreenshots.count, by: strideAmount)
+      .map { sortedScreenshots[$0] }
+
+    let firstTs = sampledScreenshots.first!.capturedAt
+    let lastTs = sampledScreenshots.last!.capturedAt
+    let durationSeconds = TimeInterval(lastTs - firstTs)
+
+    var frameDescriptions: [(timestamp: TimeInterval, description: String)] = []
+    for screenshot in sampledScreenshots {
+      guard let frameData = loadScreenshotAsFrameData(screenshot, relativeTo: firstTs) else {
+        print("[MINIMAX] ⚠️ Failed to load screenshot: \(screenshot.filePath)")
+        continue
+      }
+      if let description = await getSimpleFrameDescription(frameData, batchId: batchId) {
+        frameDescriptions.append((timestamp: frameData.timestamp, description: description))
+      }
+    }
+
+    guard !frameDescriptions.isEmpty else {
+      throw NSError(
+        domain: "MiniMaxProvider",
+        code: 11,
+        userInfo: [
+          NSLocalizedDescriptionKey:
+            "Failed to describe any screenshots. Please verify your MiniMax API key and that the model is available."
+        ]
+      )
+    }
+
+    let observations = try await mergeFrameDescriptions(
+      frameDescriptions,
+      batchStartTime: batchStartTime,
+      videoDuration: durationSeconds,
+      batchId: batchId
+    )
+
+    let totalTime = Date().timeIntervalSince(callStart)
+    let log = LLMCall(
+      timestamp: callStart,
+      latency: totalTime,
+      input: "Screenshot transcription: \(screenshots.count) screenshots → \(observations.count) observations",
+      output: "Processed \(screenshots.count) screenshots in \(String(format: "%.2f", totalTime))s"
+    )
+
+    return (observations, log)
+  }
+
+  fileprivate func loadScreenshotAsFrameData(
+    _ screenshot: Screenshot, relativeTo baseTimestamp: Int
+  ) -> FrameData? {
+    guard let imageData = loadScreenshotDataForMiniMax(screenshot) else {
+      return nil
+    }
+    let base64String = imageData.base64EncodedString()
+    let base64Data = Data(base64String.utf8)
+    let relativeTimestamp = TimeInterval(screenshot.capturedAt - baseTimestamp)
+    return FrameData(image: base64Data, timestamp: relativeTimestamp)
+  }
+
+  private func loadScreenshotDataForMiniMax(
+    _ screenshot: Screenshot, maxHeight: Double = 720, jpegQuality: CGFloat = 0.85
+  ) -> Data? {
+    let url = URL(fileURLWithPath: screenshot.filePath)
+    guard let image = NSImage(contentsOf: url) else {
+      return try? Data(contentsOf: url)
+    }
+    let rep =
+      image.representations.compactMap { $0 as? NSBitmapImageRep }.first
+      ?? image.representations.first
+    let pixelsWide = rep?.pixelsWide ?? Int(image.size.width)
+    let pixelsHigh = rep?.pixelsHigh ?? Int(image.size.height)
+
+    if pixelsHigh <= Int(maxHeight) {
+      return try? Data(contentsOf: url)
+    }
+
+    let scale = maxHeight / Double(pixelsHigh)
+    let targetW = max(2, Int((Double(pixelsWide) * scale).rounded(.toNearestOrAwayFromZero)))
+    let targetH = Int(maxHeight)
+
+    guard
+      let bitmap = NSBitmapImageRep(
+        bitmapDataPlanes: nil,
+        pixelsWide: targetW,
+        pixelsHigh: targetH,
+        bitsPerSample: 8,
+        samplesPerPixel: 4,
+        hasAlpha: true,
+        isPlanar: false,
+        colorSpaceName: .calibratedRGB,
+        bytesPerRow: 0,
+        bitsPerPixel: 0
+      )
+    else { return nil }
+
+    bitmap.size = NSSize(width: targetW, height: targetH)
+    NSGraphicsContext.saveGraphicsState()
+    guard let ctx = NSGraphicsContext(bitmapImageRep: bitmap) else {
+      NSGraphicsContext.restoreGraphicsState()
+      return nil
+    }
+    NSGraphicsContext.current = ctx
+    image.draw(
+      in: NSRect(x: 0, y: 0, width: CGFloat(targetW), height: CGFloat(targetH)),
+      from: NSRect(origin: .zero, size: image.size),
+      operation: .copy,
+      fraction: 1.0,
+      respectFlipped: true,
+      hints: [.interpolation: NSImageInterpolation.high]
+    )
+    ctx.flushGraphics()
+    NSGraphicsContext.restoreGraphicsState()
+
+    let props: [NSBitmapImageRep.PropertyKey: Any] = [.compressionFactor: jpegQuality]
+    return bitmap.representation(using: NSBitmapImageRep.FileType.jpeg, properties: props)
+  }
+}

--- a/Dayflow/Dayflow/Core/AI/MiniMaxProvider.swift
+++ b/Dayflow/Dayflow/Core/AI/MiniMaxProvider.swift
@@ -1,0 +1,253 @@
+//
+//  MiniMaxProvider.swift
+//  Dayflow
+//
+//  LLM provider for MiniMax M3 — a multimodal model from MiniMax.
+//  Uses the OpenAI-compatible Chat Completions endpoint at https://api.minimax.io/v1.
+//  API key is stored in the macOS Keychain (key: "minimax").
+//
+
+import AppKit
+import Foundation
+
+final class MiniMaxProvider {
+  // MARK: - Constants
+
+  /// The default API base URL. Can be overridden in init for tests.
+  static let defaultEndpoint = "https://api.minimax.io/v1"
+
+  /// Keychain key for the API key.
+  static let keychainKey = "minimax"
+
+  /// The default model identifier for MiniMax M3.
+  static let defaultModelId = "MiniMax-M3"
+
+  // MARK: - Stored properties
+
+  let endpoint: String
+
+  /// The current model ID. Read from UserDefaults (key: "llmMiniMaxModelId") if present,
+  /// otherwise falls back to `defaultModelId`.
+  var savedModelId: String {
+    if let m = UserDefaults.standard.string(forKey: "llmMiniMaxModelId"), !m.isEmpty {
+      return m
+    }
+    return Self.defaultModelId
+  }
+
+  /// API key loaded from Keychain. May be nil if the user has not yet configured one.
+  var apiKey: String? {
+    guard let raw = KeychainManager.shared.retrieve(for: Self.keychainKey) else { return nil }
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  /// Screenshot interval in seconds. Mirrors `OllamaProvider.screenshotInterval` so
+  /// frame-stitching logic in extensions stays consistent.
+  let screenshotInterval: TimeInterval = 10
+
+  /// For analytics tracking.
+  var providerName: String { "minimax" }
+
+  // MARK: - Init
+
+  init(endpoint: String = MiniMaxProvider.defaultEndpoint) {
+    self.endpoint = endpoint
+  }
+
+  // MARK: - Helpers (mirrored from OllamaProvider for consistency)
+
+  /// Strip user references from observations to prevent the LLM from using third-person
+  /// language. Mirrors the behaviour of `OllamaProvider.stripUserReferences`.
+  func stripUserReferences(_ text: String) -> String {
+    return text
+      .replacingOccurrences(of: "The user", with: "", options: .caseInsensitive)
+      .replacingOccurrences(of: "A user", with: "", options: .caseInsensitive)
+  }
+
+  func logCallDuration(operation: String, duration: TimeInterval, status: Int? = nil) {
+    let statusText = status.map { " status=\($0)" } ?? ""
+    print("⏱️ [MiniMax] \(operation) \(String(format: "%.2f", duration))s\(statusText)")
+  }
+
+  // MARK: - Activity card generation (public entry point)
+
+  func generateActivityCards(
+    observations: [Observation],
+    context: ActivityGenerationContext,
+    batchId: Int64?
+  ) async throws -> (cards: [ActivityCardData], log: LLMCall) {
+    let callStart = Date()
+    var logs: [String] = []
+
+    let sortedObservations = context.batchObservations.sorted { $0.startTs < $1.startTs }
+
+    guard let firstObservation = sortedObservations.first,
+      let lastObservation = sortedObservations.last
+    else {
+      throw NSError(
+        domain: "MiniMaxProvider",
+        code: 16,
+        userInfo: [
+          NSLocalizedDescriptionKey: "Cannot generate activity cards: no observations provided"
+        ]
+      )
+    }
+
+    // 1. Generate initial title+summary for these observations.
+    let (titleSummary, firstLog) = try await generateTitleAndSummary(
+      observations: sortedObservations,
+      categories: context.categories,
+      batchId: batchId
+    )
+    logs.append(firstLog)
+
+    let normalizedCategory = normalizeCategory(
+      titleSummary.category, categories: context.categories)
+
+    let initialCard = ActivityCardData(
+      startTime: formatTimestampForPrompt(firstObservation.startTs),
+      endTime: formatTimestampForPrompt(lastObservation.endTs),
+      category: normalizedCategory,
+      subcategory: "",
+      title: titleSummary.title,
+      summary: titleSummary.summary,
+      detailedSummary: "",
+      distractions: nil,
+      appSites: titleSummary.appSites
+    )
+
+    var allCards = context.existingCards
+
+    // 2. Decide whether to merge with the last existing card.
+    if !allCards.isEmpty, let lastExistingCard = allCards.last {
+      let lastCardDuration = calculateDurationInMinutes(
+        from: lastExistingCard.startTime, to: lastExistingCard.endTime)
+
+      if lastCardDuration >= 40 {
+        allCards.append(initialCard)
+      } else {
+        let gapMinutes = calculateDurationInMinutes(
+          from: lastExistingCard.endTime, to: initialCard.startTime)
+        if gapMinutes > 5 {
+          allCards.append(initialCard)
+        } else {
+          let candidateDuration = calculateDurationInMinutes(
+            from: lastExistingCard.startTime, to: initialCard.endTime)
+          if candidateDuration > 60 {
+            allCards.append(initialCard)
+          } else {
+            let (shouldMerge, mergeLog) = try await checkShouldMerge(
+              previousCard: lastExistingCard,
+              newCard: initialCard,
+              batchId: batchId
+            )
+            logs.append(mergeLog)
+
+            if shouldMerge {
+              let (mergedCard, mergeCreateLog) = try await mergeTwoCards(
+                previousCard: lastExistingCard,
+                newCard: initialCard,
+                batchId: batchId
+              )
+
+              let mergedDuration = calculateDurationInMinutes(
+                from: mergedCard.startTime, to: mergedCard.endTime)
+
+              if mergedDuration > 60 {
+                allCards.append(initialCard)
+              } else {
+                logs.append(mergeCreateLog)
+                allCards[allCards.count - 1] = mergedCard
+              }
+            } else {
+              allCards.append(initialCard)
+            }
+          }
+        }
+      }
+    } else {
+      allCards.append(initialCard)
+    }
+
+    let totalLatency = Date().timeIntervalSince(callStart)
+
+    let combinedLog = LLMCall(
+      timestamp: callStart,
+      latency: totalLatency,
+      input: "Two-pass activity card generation",
+      output: logs.joined(separator: "\n\n---\n\n")
+    )
+
+    return (allCards, combinedLog)
+  }
+
+  // MARK: - Utility helpers (also mirrored from OllamaProvider)
+
+  private func normalizeCategory(_ raw: String, categories: [LLMCategoryDescriptor]) -> String {
+    let cleaned = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !cleaned.isEmpty else { return categories.first?.name ?? "" }
+    let normalized = cleaned.lowercased()
+    if let match = categories.first(where: {
+      $0.name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == normalized
+    }) {
+      return match.name
+    }
+    if let idle = categories.first(where: { $0.isIdle }) {
+      let idleLabels = [
+        "idle", "idle time", idle.name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+      ]
+      if idleLabels.contains(normalized) {
+        return idle.name
+      }
+    }
+    return categories.first?.name ?? cleaned
+  }
+
+  func parseJSONResponse<T: Codable>(_ type: T.Type, from data: Data) throws -> T {
+    do {
+      return try JSONDecoder().decode(type, from: data)
+    } catch {
+      guard let responseString = String(data: data, encoding: .utf8) else {
+        throw error
+      }
+      if let startIndex = responseString.firstIndex(of: "{"),
+        let endIndex = responseString.lastIndex(of: "}")
+      {
+        let jsonSubstring = responseString[startIndex...endIndex]
+        if let jsonData = jsonSubstring.data(using: .utf8) {
+          return try JSONDecoder().decode(type, from: jsonData)
+        }
+      }
+      throw error
+    }
+  }
+
+  func formatTimestampForPrompt(_ timestamp: Int) -> String {
+    let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
+    let formatter = DateFormatter()
+    formatter.dateFormat = "h:mm a"
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone.current
+    return formatter.string(from: date)
+  }
+
+  private func calculateDurationInMinutes(from startTime: String, to endTime: String) -> Int {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "h:mm a"
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone.current
+
+    guard let start = formatter.date(from: startTime),
+      let end = formatter.date(from: endTime)
+    else {
+      return 0
+    }
+
+    var duration = end.timeIntervalSince(start)
+    if duration < 0 {
+      duration += 24 * 60 * 60
+    }
+    return Int(duration / 60)
+  }
+}

--- a/Dayflow/Dayflow/Core/AI/ModelCatalog.swift
+++ b/Dayflow/Dayflow/Core/AI/ModelCatalog.swift
@@ -1,0 +1,517 @@
+//
+//  ModelCatalog.swift
+//  Dayflow
+//
+//  Centralized model catalog for all LLM providers. Lets the user pick from
+//  models fetched live from the provider's API where possible, falling back
+//  to a curated static list where the provider doesn't expose a list endpoint.
+//
+//  Each provider has a `fetchModels()` implementation. Results are cached in
+//  UserDefaults with a TTL so we don't hammer the API on every app launch.
+//
+
+import AppKit
+import Foundation
+
+// MARK: - Model option
+
+struct LLMModelOption: Codable, Identifiable, Hashable {
+  let id: String
+  let displayName: String
+  let family: String
+  let contextWindow: Int?
+  let visionCapable: Bool
+  let isDeprecated: Bool
+  let isRecommended: Bool
+  let notes: String?
+}
+
+extension LLMModelOption {
+  static func curated(
+    _ id: String,
+    displayName: String? = nil,
+    family: String = "",
+    contextWindow: Int? = nil,
+    visionCapable: Bool = false,
+    isDeprecated: Bool = false,
+    isRecommended: Bool = false,
+    notes: String? = nil
+  ) -> LLMModelOption {
+    LLMModelOption(
+      id: id,
+      displayName: displayName ?? id,
+      family: family,
+      contextWindow: contextWindow,
+      visionCapable: visionCapable,
+      isDeprecated: isDeprecated,
+      isRecommended: isRecommended,
+      notes: notes
+    )
+  }
+}
+
+// MARK: - Cached list
+
+struct ModelListSnapshot: Codable {
+  let providerID: String
+  let models: [LLMModelOption]
+  let fetchedAt: Date
+  let source: Source
+  let fetchError: String?
+
+  enum Source: String, Codable {
+    case live  // came from the provider API
+    case curated  // from the in-app fallback list
+  }
+
+  var isStale: Bool {
+    Date().timeIntervalSince(fetchedAt) > 24 * 60 * 60
+  }
+}
+
+// MARK: - Catalog
+
+actor ModelCatalog {
+  static let shared = ModelCatalog()
+
+  private let cacheKey = "llmModelCatalogCache.v1"
+  private let ttl: TimeInterval = 24 * 60 * 60  // 24h
+
+  private var cache: [String: ModelListSnapshot] = [:]
+  private var inFlight: [String: Task<ModelListSnapshot, Error>] = [:]
+
+  init() {
+    if let data = UserDefaults.standard.data(forKey: cacheKey),
+      let decoded = try? JSONDecoder().decode([String: ModelListSnapshot].self, from: data)
+    {
+      cache = decoded
+    }
+  }
+
+  // MARK: Public read
+
+  func cachedList(for providerID: String) -> ModelListSnapshot? {
+    cache[providerID]
+  }
+
+  /// Returns the cached list immediately (possibly stale) and then triggers a
+  /// background refresh. The UI binds to the returned snapshot and re-renders
+  /// when the refresh finishes.
+  func snapshot(for providerID: String) -> ModelListSnapshot? {
+    cache[providerID]
+  }
+
+  // MARK: Public refresh
+
+  /// Force a fresh fetch from the provider. Falls back to the curated list
+  /// when the network call fails.
+  func refresh(for providerID: String) async throws -> ModelListSnapshot {
+    if let inflight = inFlight[providerID] {
+      return try await inflight.value
+    }
+    let task = Task<ModelListSnapshot, Error> { [weak self] in
+      guard let self else { throw CancellationError() }
+      return try await self.performFetch(for: providerID)
+    }
+    inFlight[providerID] = task
+    defer { inFlight[providerID] = nil }
+    let snapshot = try await task.value
+    cache[providerID] = snapshot
+    persistCache()
+    return snapshot
+  }
+
+  /// Used when the user picks a model that isn't in the current snapshot —
+  /// e.g. a custom model ID or one that was just removed from the API.
+  func ensureModelExists(_ modelID: String, in providerID: String) {
+    guard var snapshot = cache[providerID] else { return }
+    if snapshot.models.contains(where: { $0.id == modelID }) { return }
+    let custom = LLMModelOption.curated(
+      modelID, displayName: "\(modelID) (custom)", isRecommended: false)
+    snapshot = ModelListSnapshot(
+      providerID: providerID,
+      models: [custom] + snapshot.models,
+      fetchedAt: snapshot.fetchedAt,
+      source: snapshot.source,
+      fetchError: snapshot.fetchError
+    )
+    cache[providerID] = snapshot
+    persistCache()
+  }
+
+  // MARK: Internals
+
+  private func performFetch(for providerID: String) async throws -> ModelListSnapshot {
+    do {
+      let models: [LLMModelOption]
+      switch providerID {
+      case "gemini":
+        models = try await fetchGeminiModels()
+      case "minimax":
+        models = try await fetchMiniMaxModels()
+      case "ollama":
+        models = try await fetchOllamaModels()
+      case "codex":
+        models = curatedCodexModels
+      case "claude":
+        models = curatedClaudeModels
+      default:
+        models = []
+      }
+      return ModelListSnapshot(
+        providerID: providerID,
+        models: models,
+        fetchedAt: Date(),
+        source: .live,
+        fetchError: nil
+      )
+    } catch {
+      let fallback = ModelListSnapshot(
+        providerID: providerID,
+        models: curatedFallback(for: providerID),
+        fetchedAt: Date(),
+        source: .curated,
+        fetchError: error.localizedDescription
+      )
+      return fallback
+    }
+  }
+
+  private func persistCache() {
+    if let data = try? JSONEncoder().encode(cache) {
+      UserDefaults.standard.set(data, forKey: cacheKey)
+    }
+  }
+
+  // MARK: Per-provider live fetchers
+
+  private func fetchGeminiModels() async throws -> [LLMModelOption] {
+    guard let apiKey = KeychainManager.shared.retrieve(for: "gemini"),
+      !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else {
+      throw NSError(
+        domain: "ModelCatalog", code: 401,
+        userInfo: [NSLocalizedDescriptionKey: "Gemini API key is not configured"])
+    }
+    var components = URLComponents(string: "https://generativelanguage.googleapis.com/v1beta/models")
+    components?.queryItems = [URLQueryItem(name: "key", value: apiKey)]
+    guard let url = components?.url else {
+      throw NSError(
+        domain: "ModelCatalog", code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "Invalid Gemini models URL"])
+    }
+
+    struct Resp: Codable {
+      let models: [Model]
+      struct Model: Codable {
+        let name: String
+        let displayName: String?
+        let inputTokenLimit: Int?
+        let outputTokenLimit: Int?
+        let supportedGenerationMethods: [String]?
+
+        enum CodingKeys: String, CodingKey {
+          case name
+          case displayName = "displayName"
+          case inputTokenLimit = "inputTokenLimit"
+          case outputTokenLimit = "outputTokenLimit"
+          case supportedGenerationMethods = "supportedGenerationMethods"
+        }
+      }
+    }
+
+    let (data, response) = try await URLSession.shared.data(from: url)
+    guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+      let body = String(data: data, encoding: .utf8) ?? "Unknown error"
+      throw NSError(
+        domain: "ModelCatalog", code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "Gemini models endpoint error: \(body)"])
+    }
+    let decoded = try JSONDecoder().decode(Resp.self, from: data)
+    return decoded.models.compactMap { m in
+      let family = m.name.split(separator: "-").first.map(String.init) ?? ""
+      let vision = m.supportedGenerationMethods?.contains("generateContent") == true
+      let deprecated = m.name.contains("1.0") || m.name.contains("1.5")
+      return LLMModelOption.curated(
+        m.name,
+        displayName: m.displayName ?? m.name,
+        family: family,
+        contextWindow: m.inputTokenLimit,
+        visionCapable: vision,
+        isDeprecated: deprecated,
+        isRecommended: m.name.contains("2.5") || m.name.contains("2.0-flash"),
+        notes: nil
+      )
+    }
+  }
+
+  private func fetchMiniMaxModels() async throws -> [LLMModelOption] {
+    guard let url = URL(string: "https://api.minimax.io/v1/models") else {
+      throw NSError(
+        domain: "ModelCatalog", code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "Invalid MiniMax models URL"])
+    }
+    var req = URLRequest(url: url)
+    req.httpMethod = "GET"
+    req.timeoutInterval = 30
+    if let key = KeychainManager.shared.retrieve(for: MiniMaxProvider.keychainKey),
+      !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    {
+      req.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+    }
+    struct Resp: Codable {
+      let data: [Model]
+      struct Model: Codable {
+        let id: String
+      }
+    }
+    let (data, response) = try await URLSession.shared.data(for: req)
+    guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+      let body = String(data: data, encoding: .utf8) ?? "Unknown error"
+      throw NSError(
+        domain: "ModelCatalog", code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "MiniMax models endpoint error: \(body)"])
+    }
+    let decoded = try JSONDecoder().decode(Resp.self, from: data)
+    return decoded.data.map { m in
+      let family: String
+      if m.id.lowercased().contains("m3") { family = "M3" }
+      else if m.id.lowercased().contains("m2") { family = "M2" }
+      else { family = "M-series" }
+      return LLMModelOption.curated(
+        m.id, family: family, visionCapable: true,
+        isRecommended: m.id == "MiniMax-M3",
+        notes: m.id == "MiniMax-M3" ? "Default. 1M-token context, multimodal." : nil
+      )
+    }
+  }
+
+  private func fetchOllamaModels() async throws -> [LLMModelOption] {
+    let baseURL = UserDefaults.standard.string(forKey: "llmLocalBaseURL") ?? "http://localhost:11434"
+    let engine = UserDefaults.standard.string(forKey: "llmLocalEngine") ?? "ollama"
+    let trimmedBase = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+    let urlString: String
+    if engine == "lmstudio" {
+      urlString = "\(trimmedBase)/v1/models"
+    } else {
+      urlString = "\(trimmedBase)/api/tags"
+    }
+    guard let url = URL(string: urlString) else {
+      throw NSError(
+        domain: "ModelCatalog", code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "Invalid local models URL"])
+    }
+    var req = URLRequest(url: url)
+    req.httpMethod = "GET"
+    req.timeoutInterval = 15
+    if engine == "lmstudio" {
+      req.setValue("Bearer lm-studio", forHTTPHeaderField: "Authorization")
+    }
+
+    struct OllamaResp: Codable {
+      let models: [OllamaModel]
+      struct OllamaModel: Codable {
+        let name: String
+        let size: Int64?
+        let details: Details?
+        struct Details: Codable {
+          let family: String?
+          let parameter_size: String?
+        }
+      }
+    }
+    struct LMSResp: Codable {
+      let data: [LMModel]
+      struct LMModel: Codable {
+        let id: String
+      }
+    }
+    let (data, response) = try await URLSession.shared.data(for: req)
+    guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+      let body = String(data: data, encoding: .utf8) ?? "Unknown error"
+      throw NSError(
+        domain: "ModelCatalog", code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "Local models endpoint error: \(body)"])
+    }
+    if engine == "lmstudio" {
+      let decoded = try JSONDecoder().decode(LMSResp.self, from: data)
+      return decoded.data.map { m in
+        LLMModelOption.curated(
+          m.id, family: "Local",
+          visionCapable: isLikelyVisionModel(m.id),
+          isRecommended: m.id.contains("qwen3-vl") || m.id.contains("vision"))
+      }
+    } else {
+      let decoded = try JSONDecoder().decode(OllamaResp.self, from: data)
+      return decoded.models.map { m in
+        LLMModelOption.curated(
+          m.name, family: m.details?.family ?? "Local",
+          visionCapable: isLikelyVisionModel(m.name),
+          isRecommended: m.name.contains("qwen3-vl") || m.name.contains("vision")
+        )
+      }
+    }
+  }
+
+  private func isLikelyVisionModel(_ name: String) -> Bool {
+    let lower = name.lowercased()
+    return lower.contains("vl") || lower.contains("vision") || lower.contains("llava")
+      || lower.contains("qwen2.5vl") || lower.contains("qwen3-vl")
+  }
+
+  // MARK: Curated fallbacks (used when live fetch fails or for providers
+  // that have no public list endpoint)
+
+  private func curatedFallback(for providerID: String) -> [LLMModelOption] {
+    switch providerID {
+    case "gemini": return curatedGeminiModels
+    case "minimax": return curatedMiniMaxModels
+    case "ollama": return curatedOllamaModels
+    case "codex": return curatedCodexModels
+    case "claude": return curatedClaudeModels
+    default: return []
+    }
+  }
+
+  private var curatedGeminiModels: [LLMModelOption] {
+    [
+      .curated(
+        "gemini-3.5-flash", displayName: "Gemini 3.5 Flash", family: "Gemini 3.5",
+        contextWindow: 1_048_576, visionCapable: true, isRecommended: true,
+        notes: "Default workhorse. Fast, 1M context, multimodal."
+      ),
+      .curated(
+        "gemini-2.5-pro", displayName: "Gemini 2.5 Pro", family: "Gemini 2.5",
+        contextWindow: 1_048_576, visionCapable: true, isRecommended: false,
+        notes: "Best for complex reasoning. Scheduled for shutdown 2026-10-16."
+      ),
+      .curated(
+        "gemini-2.5-flash", displayName: "Gemini 2.5 Flash", family: "Gemini 2.5",
+        contextWindow: 1_048_576, visionCapable: true, isRecommended: false,
+        notes: "Faster, lower cost. Scheduled for shutdown 2026-10-16."
+      ),
+      .curated(
+        "gemini-2.5-flash-lite", displayName: "Gemini 2.5 Flash-Lite",
+        family: "Gemini 2.5", contextWindow: 1_048_576, visionCapable: true,
+        isRecommended: false, notes: "Cheapest, fastest."
+      ),
+      .curated(
+        "gemini-2.0-flash", displayName: "Gemini 2.0 Flash", family: "Gemini 2.0",
+        contextWindow: 1_048_576, visionCapable: true, isDeprecated: true,
+        notes: "Shut down 2026-06-01."
+      ),
+      .curated(
+        "gemini-1.5-pro", displayName: "Gemini 1.5 Pro", family: "Gemini 1.5",
+        contextWindow: 2_097_152, visionCapable: true, isDeprecated: true,
+        notes: "Deprecated."
+      ),
+    ]
+  }
+
+  private var curatedMiniMaxModels: [LLMModelOption] {
+    [
+      .curated(
+        "MiniMax-M3", displayName: "MiniMax M3", family: "M3",
+        contextWindow: 1_000_000, visionCapable: true, isRecommended: true,
+        notes: "Default. Frontier multimodal, 1M context."
+      ),
+      .curated(
+        "MiniMax-M2.7", displayName: "MiniMax M2.7", family: "M2",
+        contextWindow: 1_000_000, visionCapable: true, isRecommended: false,
+        notes: "Previous flagship."
+      ),
+      .curated(
+        "MiniMax-M2.7-highspeed", displayName: "MiniMax M2.7 Highspeed",
+        family: "M2", contextWindow: 1_000_000, visionCapable: true,
+        isRecommended: false, notes: "Lower-latency M2.7."
+      ),
+      .curated(
+        "MiniMax-M2.5", displayName: "MiniMax M2.5", family: "M2",
+        contextWindow: 1_000_000, visionCapable: true, isRecommended: false
+      ),
+      .curated(
+        "MiniMax-M2.5-highspeed", displayName: "MiniMax M2.5 Highspeed",
+        family: "M2", contextWindow: 1_000_000, visionCapable: true,
+        isRecommended: false
+      ),
+    ]
+  }
+
+  private var curatedOllamaModels: [LLMModelOption] {
+    [
+      .curated("qwen3-vl:4b", displayName: "Qwen3-VL 4B (Recommended)",
+               family: "Qwen3-VL", contextWindow: 32_768, visionCapable: true,
+               isRecommended: true,
+               notes: "Dayflow's recommended local VLM."),
+      .curated("qwen2.5vl:3b", displayName: "Qwen2.5-VL 3B",
+               family: "Qwen2.5-VL", contextWindow: 32_768, visionCapable: true,
+               isRecommended: false),
+      .curated("llama3.2-vision:11b", displayName: "Llama 3.2 Vision 11B",
+               family: "Llama 3.2", contextWindow: 128_000, visionCapable: true,
+               isRecommended: false),
+      .curated("llava:13b", displayName: "LLaVA 13B",
+               family: "LLaVA", contextWindow: 4_096, visionCapable: true,
+               isRecommended: false),
+      .curated("gemma3:4b", displayName: "Gemma 3 4B",
+               family: "Gemma 3", contextWindow: 128_000, visionCapable: true,
+               isRecommended: false),
+    ]
+  }
+
+  private var curatedCodexModels: [LLMModelOption] {
+    [
+      .curated("gpt-4o", displayName: "GPT-4o", family: "GPT-4o",
+               contextWindow: 128_000, visionCapable: true, isRecommended: true),
+      .curated("gpt-4o-mini", displayName: "GPT-4o mini", family: "GPT-4o",
+               contextWindow: 128_000, visionCapable: true, isRecommended: false),
+      .curated("gpt-4.1", displayName: "GPT-4.1", family: "GPT-4.1",
+               contextWindow: 1_000_000, visionCapable: true, isRecommended: false),
+      .curated("gpt-4.1-mini", displayName: "GPT-4.1 mini", family: "GPT-4.1",
+               contextWindow: 1_000_000, visionCapable: true, isRecommended: false),
+      .curated("o3", displayName: "o3", family: "o-series",
+               contextWindow: 200_000, visionCapable: false, isRecommended: false),
+      .curated("o3-mini", displayName: "o3-mini", family: "o-series",
+               contextWindow: 200_000, visionCapable: false, isRecommended: false),
+      .curated("o4-mini", displayName: "o4-mini", family: "o-series",
+               contextWindow: 200_000, visionCapable: false, isRecommended: false),
+    ]
+  }
+
+  private var curatedClaudeModels: [LLMModelOption] {
+    [
+      .curated(
+        "claude-opus-4-8", displayName: "Claude Opus 4.8", family: "Opus",
+        contextWindow: 1_000_000, visionCapable: true, isRecommended: true,
+        notes: "Frontier. Best for complex agent tasks."
+      ),
+      .curated(
+        "claude-opus-4-7", displayName: "Claude Opus 4.7", family: "Opus",
+        contextWindow: 1_000_000, visionCapable: true, isRecommended: false
+      ),
+      .curated(
+        "claude-sonnet-4-5", displayName: "Claude Sonnet 4.5", family: "Sonnet",
+        contextWindow: 1_000_000, visionCapable: true, isRecommended: false,
+        notes: "Dayflow's default. Good balance."
+      ),
+      .curated(
+        "claude-3-5-sonnet-latest", displayName: "Claude 3.5 Sonnet (latest)",
+        family: "Sonnet", contextWindow: 200_000, visionCapable: true,
+        isDeprecated: true
+      ),
+      .curated(
+        "claude-3-5-haiku-latest", displayName: "Claude 3.5 Haiku (latest)",
+        family: "Haiku", contextWindow: 200_000, visionCapable: true,
+        isRecommended: false, notes: "Cheapest, fastest Claude."
+      ),
+    ]
+  }
+}
+
+// MARK: - Provider id helpers
+
+extension LLMProviderID {
+  /// The provider-id used by `ModelCatalog`. (Today this is the same string
+  /// the settings UI uses, but keeping the indirection lets us rename later
+  /// without rewriting every catalog call site.)
+  var modelCatalogID: String { rawValue }
+}

--- a/Dayflow/Dayflow/Core/Analytics/ProviderStatsCalculator.swift
+++ b/Dayflow/Dayflow/Core/Analytics/ProviderStatsCalculator.swift
@@ -1,0 +1,209 @@
+//
+//  ProviderStatsCalculator.swift
+//  Dayflow
+//
+//  Derives per-provider / per-model / per-day / per-week usage statistics
+//  from a list of `TimelineCard`s. Used by the dashboard view to render
+//  the GitHub-commit-style heatmap and the provider breakdown.
+//
+
+import Foundation
+
+// MARK: - Public models
+
+struct ProviderStatsSummary {
+  /// Total number of cards in the input. Cached because every view re-reads it.
+  let totalCards: Int
+
+  /// Cards per provider ID ("gemini", "minimax", "ollama", "chatgpt_claude", "dayflow").
+  /// Always includes an entry for the 5 known providers, even if zero.
+  let byProvider: [String: Int]
+
+  /// Cards per (providerID|modelID) tuple — the per-model breakdown.
+  let byModel: [(providerID: String, modelID: String, count: Int)]
+
+  /// Daily buckets covering the most recent `days` days (default 365).
+  let daily: [DailyStat]
+  /// Weekly buckets covering the most recent `weeks` weeks (default 26).
+  let weekly: [WeeklyStat]
+  /// Monthly buckets covering the most recent `months` months (default 12).
+  let monthly: [MonthlyStat]
+
+  /// Earliest card date in the dataset (or nil if no cards).
+  let earliest: Date?
+  /// Latest card date in the dataset (or nil if no cards).
+  let latest: Date?
+
+  /// A flat (date, count) list for the GitHub-style heatmap (defaults to the
+  /// last 365 days). The view is responsible for rendering the grid.
+  let heatmapDays: [HeatmapDay]
+
+  /// The most active day in `daily`, useful as a quick callout.
+  let peakDay: DailyStat?
+}
+
+struct DailyStat: Identifiable, Hashable {
+  var id: Date { date }
+  let date: Date
+  let count: Int
+}
+
+struct WeeklyStat: Identifiable, Hashable {
+  var id: Date { weekStart }
+  let weekStart: Date  // Monday of the week
+  let count: Int
+}
+
+struct MonthlyStat: Identifiable, Hashable {
+  var id: Date { monthStart }
+  let monthStart: Date  // First day of the month
+  let count: Int
+}
+
+struct HeatmapDay: Identifiable, Hashable {
+  var id: Date { date }
+  let date: Date
+  let count: Int
+  /// Normalized intensity 0...1, where 1.0 = peak day in the dataset.
+  let intensity: Double
+}
+
+// MARK: - Calculator
+
+enum ProviderStatsCalculator {
+  static let knownProviders: [String] = [
+    "gemini", "minimax", "ollama", "chatgpt_claude", "dayflow"
+  ]
+
+  /// Compute a summary from a list of cards. The cards may span any time
+  /// range; the calculator normalizes to calendar boundaries (Mon-Sun weeks,
+  /// 1st-of-month months, …).
+  static func summary(
+    from cards: [TimelineCard],
+    days: Int = 365,
+    weeks: Int = 26,
+    months: Int = 12,
+    calendar: Calendar = .current
+  ) -> ProviderStatsSummary {
+    let total = cards.count
+
+    // byProvider
+    var byProvider: [String: Int] = [:]
+    for p in knownProviders { byProvider[p] = 0 }
+    for card in cards {
+      let key = (card.providerId ?? "unknown").trimmingCharacters(in: .whitespacesAndNewlines)
+      let bucket = key.isEmpty ? "unknown" : key
+      byProvider[bucket, default: 0] += 1
+    }
+
+    // byModel
+    var byModelDict: [String: (providerID: String, modelID: String, count: Int)] = [:]
+    for card in cards {
+      let p = (card.providerId ?? "unknown").trimmingCharacters(in: .whitespacesAndNewlines)
+      let m = (card.modelId ?? "unknown").trimmingCharacters(in: .whitespacesAndNewlines)
+      let pKey = p.isEmpty ? "unknown" : p
+      let mKey = m.isEmpty ? "unknown" : m
+      let key = "\(pKey)|\(mKey)"
+      if var existing = byModelDict[key] {
+        existing.count += 1
+        byModelDict[key] = existing
+      } else {
+        byModelDict[key] = (providerID: pKey, modelID: mKey, count: 1)
+      }
+    }
+    let byModel = byModelDict.values
+      .sorted { lhs, rhs in
+        if lhs.count != rhs.count { return lhs.count > rhs.count }
+        if lhs.providerID != rhs.providerID { return lhs.providerID < rhs.providerID }
+        return lhs.modelID < rhs.modelID
+      }
+
+    // Date parsing helpers
+    func parseDate(_ s: String) -> Date? {
+      let formatters: [DateFormatter] = {
+        let iso = DateFormatter()
+        iso.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        iso.locale = Locale(identifier: "en_US_POSIX")
+        let alt = DateFormatter()
+        alt.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        alt.locale = Locale(identifier: "en_US_POSIX")
+        return [iso, alt]
+      }()
+      for f in formatters { if let d = f.date(from: s) { return d } }
+      return nil
+    }
+
+    let dates: [Date] = cards.compactMap { parseDate($0.startTimestamp) }
+    let earliest = dates.min()
+    let latest = dates.max()
+
+    // Daily
+    let today = calendar.startOfDay(for: Date())
+    var dailyCounts: [Date: Int] = [:]
+    for d in dates {
+      let day = calendar.startOfDay(for: d)
+      dailyCounts[day, default: 0] += 1
+    }
+    let daily: [DailyStat] = (0..<days).reversed().map { offset in
+      let day = calendar.date(byAdding: .day, value: -offset, to: today) ?? today
+      return DailyStat(date: day, count: dailyCounts[day] ?? 0)
+    }
+
+    // Weekly
+    var weeklyCounts: [Date: Int] = [:]
+    for d in dates {
+      let comps = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: d)
+      if let weekStart = calendar.date(from: comps) {
+        weeklyCounts[weekStart, default: 0] += 1
+      }
+    }
+    let weekly: [WeeklyStat] = (0..<weeks).reversed().compactMap { offset in
+      guard let weekStart = calendar.date(
+        byAdding: .weekOfYear, value: -offset,
+        to: calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: today)) ?? today
+      ) else { return nil }
+      return WeeklyStat(weekStart: weekStart, count: weeklyCounts[weekStart] ?? 0)
+    }
+
+    // Monthly
+    var monthlyCounts: [Date: Int] = [:]
+    for d in dates {
+      let comps = calendar.dateComponents([.year, .month], from: d)
+      if let monthStart = calendar.date(from: comps) {
+        monthlyCounts[monthStart, default: 0] += 1
+      }
+    }
+    let monthly: [MonthlyStat] = (0..<months).reversed().compactMap { offset in
+      guard let monthStart = calendar.date(
+        byAdding: .month, value: -offset,
+        to: calendar.date(from: calendar.dateComponents([.year, .month], from: today)) ?? today
+      ) else { return nil }
+      return MonthlyStat(monthStart: monthStart, count: monthlyCounts[monthStart] ?? 0)
+    }
+
+    // Heatmap
+    let peak = max(1, daily.map(\.count).max() ?? 1)
+    let heatmapDays: [HeatmapDay] = daily.map { day in
+      HeatmapDay(
+        date: day.date,
+        count: day.count,
+        intensity: min(1.0, Double(day.count) / Double(peak))
+      )
+    }
+
+    let peakDay = daily.max(by: { $0.count < $1.count })
+
+    return ProviderStatsSummary(
+      totalCards: total,
+      byProvider: byProvider,
+      byModel: byModel,
+      daily: daily,
+      weekly: weekly,
+      monthly: monthly,
+      earliest: earliest,
+      latest: latest,
+      heatmapDays: heatmapDays,
+      peakDay: peakDay
+    )
+  }
+}

--- a/Dayflow/Dayflow/Core/Recording/StorageManager+TimelineCards.swift
+++ b/Dayflow/Dayflow/Core/Recording/StorageManager+TimelineCards.swift
@@ -97,14 +97,16 @@ extension StorageManager {
         sql: """
               INSERT INTO timeline_cards(
                   batch_id, start, end, start_ts, end_ts, day, title,
-                  summary, category, subcategory, detailed_summary, metadata
+                  summary, category, subcategory, detailed_summary, metadata,
+                  provider_id, model_id
                   -- video_summary_url is omitted here
               )
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           """,
         arguments: [
           batchId, card.startTimestamp, card.endTimestamp, startTs, endTs, dayString, card.title,
           card.summary, card.category, card.subcategory, card.detailedSummary, metadataString,
+          card.providerId, card.modelId
         ])
       lastId = db.lastInsertedRowID
     }
@@ -468,6 +470,65 @@ extension StorageManager {
       }
     }
     return cards ?? []
+  }
+
+  /// All non-deleted timeline cards across every day, ordered by start_ts desc.
+  /// Used by the dashboard statistics view. Implementation mirrors
+  /// `fetchTimelineCardsByTimeRange` but skips the time-range filter.
+  func fetchAllTimelineCards() async -> [TimelineCard] {
+    let decoder = JSONDecoder()
+    return await withCheckedContinuation { continuation in
+      DispatchQueue.global(qos: .userInitiated).async {
+        let cards: [TimelineCard]? = try? self.timedRead("fetchAllTimelineCards") { db in
+          try Row.fetchAll(
+            db,
+            sql: """
+                  SELECT * FROM timeline_cards
+                  WHERE is_deleted = 0
+                  ORDER BY start_ts DESC
+              """
+          )
+          .map { row in
+            // Decode metadata JSON (supports object or legacy array)
+            var distractions: [Distraction]? = nil
+            var appSites: AppSites? = nil
+            var isBackupGenerated: Bool? = nil
+            if let metadataString: String = row["metadata"],
+              let jsonData = metadataString.data(using: .utf8)
+            {
+              if let meta = try? decoder.decode(TimelineMetadata.self, from: jsonData) {
+                distractions = meta.distractions
+                appSites = meta.appSites
+                isBackupGenerated = meta.isBackupGenerated
+              } else if let legacy = try? decoder.decode([Distraction].self, from: jsonData) {
+                distractions = legacy
+              }
+            }
+
+            return TimelineCard(
+              recordId: row["id"],
+              batchId: row["batch_id"],
+              startTimestamp: row["start"] ?? "",
+              endTimestamp: row["end"] ?? "",
+              category: row["category"] ?? "Other",
+              subcategory: row["subcategory"] ?? "",
+              title: row["title"] ?? "",
+              summary: row["summary"] ?? "",
+              detailedSummary: row["detailed_summary"] ?? "",
+              day: row["day"] ?? "",
+              distractions: distractions,
+              videoSummaryURL: row["video_summary_url"],
+              otherVideoSummaryURLs: nil,
+              appSites: appSites,
+              isBackupGenerated: isBackupGenerated,
+              providerId: row["provider_id"],
+              modelId: row["model_id"]
+            )
+          }
+        }
+        continuation.resume(returning: cards ?? [])
+      }
+    }
   }
 
   func fetchTimelineCardsByTimeRange(from: Date, to: Date) -> [TimelineCard] {

--- a/Dayflow/Dayflow/Core/Recording/StorageManager+TimelineCards.swift
+++ b/Dayflow/Dayflow/Core/Recording/StorageManager+TimelineCards.swift
@@ -270,6 +270,10 @@ extension StorageManager {
     let selectedProvider = UserDefaults.standard.string(forKey: "selectedLLMProvider") ?? "gemini"
 
     switch selectedProvider {
+    case "minimax":
+      return
+        "You successfully installed Dayflow and configured it with MiniMax M3. Come back in 30 minutes to see your first real activity card! ✨ (This is a sample card, so you can see what your timeline will look like.)"
+
     case "gemini":
       return
         "You successfully installed Dayflow and configured it with Gemini AI. Come back in 30 minutes to see your first real activity card! ✨ (This is a sample card, so you can see what your timeline will look like.)"

--- a/Dayflow/Dayflow/Core/Recording/StorageManager.swift
+++ b/Dayflow/Dayflow/Core/Recording/StorageManager.swift
@@ -510,11 +510,14 @@ final class StorageManager: StorageManaging, @unchecked Sendable {
                   detailed_summary TEXT,
                   metadata TEXT,             -- For distractions JSON
                   video_summary_url TEXT,    -- Link to video summary on filesystem
+                  provider_id TEXT,          -- Which Dayflow provider produced this card
+                  model_id TEXT,             -- Which model the provider used
                   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
               );
               CREATE INDEX IF NOT EXISTS idx_timeline_cards_day ON timeline_cards(day);
               CREATE INDEX IF NOT EXISTS idx_timeline_cards_start_ts ON timeline_cards(start_ts);
               CREATE INDEX IF NOT EXISTS idx_timeline_cards_time_range ON timeline_cards(start_ts, end_ts);
+              CREATE INDEX IF NOT EXISTS idx_timeline_cards_provider_model ON timeline_cards(provider_id, model_id);
 
               -- Timeline review ratings: stores time-based review segments
               CREATE TABLE IF NOT EXISTS timeline_review_ratings (
@@ -699,6 +702,23 @@ final class StorageManager: StorageManaging, @unchecked Sendable {
 
         print("✅ Added is_deleted column and composite indexes to timeline_cards")
       }
+
+      // Migration: Add provider_id / model_id columns to timeline_cards.
+      // These are populated by the LLMService on every card produced going
+      // forward, and are read by the dashboard statistics view.
+      if !timelineCardsColumns.contains("provider_id") {
+        try db.execute(
+          sql: "ALTER TABLE timeline_cards ADD COLUMN provider_id TEXT;")
+      }
+      if !timelineCardsColumns.contains("model_id") {
+        try db.execute(
+          sql: "ALTER TABLE timeline_cards ADD COLUMN model_id TEXT;")
+      }
+      try db.execute(
+        sql: """
+              CREATE INDEX IF NOT EXISTS idx_timeline_cards_provider_model
+              ON timeline_cards(provider_id, model_id);
+          """)
 
       let screenshotColumns = try db.columns(in: "screenshots").map { $0.name }
       if !screenshotColumns.contains("idle_seconds_at_capture") {

--- a/Dayflow/Dayflow/Core/Recording/StorageManaging.swift
+++ b/Dayflow/Dayflow/Core/Recording/StorageManaging.swift
@@ -31,6 +31,10 @@ protocol StorageManaging: Sendable {
   func fetchTimelineCards(forBatch batchId: Int64) -> [TimelineCard]
   func fetchTimelineCard(byId id: Int64) -> TimelineCardWithTimestamps?
   func fetchLastTimelineCard(endingBefore: Date) -> TimelineCardWithTimestamps?
+  /// All non-deleted timeline cards across all days. Used by the dashboard
+  /// statistics view. Order: by `start_ts` descending so recent activity
+  /// surfaces first.
+  func fetchAllTimelineCards() async -> [TimelineCard]
 
   // Timeline Queries
   func fetchTimelineCards(forDay day: String) -> [TimelineCard]

--- a/Dayflow/Dayflow/Core/Recording/StorageModels.swift
+++ b/Dayflow/Dayflow/Core/Recording/StorageModels.swift
@@ -115,6 +115,12 @@ struct TimelineCard: Codable, Sendable, Identifiable {
   let otherVideoSummaryURLs: [String]?  // For merged cards, subsequent video URLs
   let appSites: AppSites?
   let isBackupGenerated: Bool?
+  /// Which Dayflow provider produced this card. Persisted so the timeline
+  /// can show the badge without having to re-derive it. Optional for
+  /// backward-compatibility with rows saved before this field existed.
+  let providerId: String?
+  /// Which model the provider used.
+  let modelId: String?
 
   init(
     id: UUID = UUID(),
@@ -132,7 +138,9 @@ struct TimelineCard: Codable, Sendable, Identifiable {
     videoSummaryURL: String?,
     otherVideoSummaryURLs: [String]?,
     appSites: AppSites?,
-    isBackupGenerated: Bool? = nil
+    isBackupGenerated: Bool? = nil,
+    providerId: String? = nil,
+    modelId: String? = nil
   ) {
     self.id = id
     self.recordId = recordId
@@ -150,6 +158,8 @@ struct TimelineCard: Codable, Sendable, Identifiable {
     self.otherVideoSummaryURLs = otherVideoSummaryURLs
     self.appSites = appSites
     self.isBackupGenerated = isBackupGenerated
+    self.providerId = providerId
+    self.modelId = modelId
   }
 }
 
@@ -234,6 +244,12 @@ struct TimelineCardShell: Sendable {
   let appSites: AppSites?
   let isBackupGenerated: Bool?
   let idleMetadata: IdleCardMetadata?
+  /// Which Dayflow provider produced this card (e.g. "minimax"). Optional
+  /// for backward-compatibility with cards saved before the dashboard feature.
+  let providerId: String?
+  /// Which model the provider used (e.g. "MiniMax-M3"). Optional for the
+  /// same backward-compat reason.
+  let modelId: String?
   // No videoSummaryURL here, as it's added later
   // No batchId here, as it's passed as a separate parameter to the save function
 
@@ -248,7 +264,9 @@ struct TimelineCardShell: Sendable {
     distractions: [Distraction]?,
     appSites: AppSites?,
     isBackupGenerated: Bool? = nil,
-    idleMetadata: IdleCardMetadata? = nil
+    idleMetadata: IdleCardMetadata? = nil,
+    providerId: String? = nil,
+    modelId: String? = nil
   ) {
     self.startTimestamp = startTimestamp
     self.endTimestamp = endTimestamp
@@ -261,6 +279,8 @@ struct TimelineCardShell: Sendable {
     self.appSites = appSites
     self.isBackupGenerated = isBackupGenerated
     self.idleMetadata = idleMetadata
+    self.providerId = providerId
+    self.modelId = modelId
   }
 }
 

--- a/Dayflow/Dayflow/Utilities/MiniMaxAPIHelper.swift
+++ b/Dayflow/Dayflow/Utilities/MiniMaxAPIHelper.swift
@@ -1,0 +1,94 @@
+//
+//  MiniMaxAPIHelper.swift
+//  Dayflow
+//
+//  Small utilities specific to the MiniMax provider.
+//
+
+import Foundation
+
+enum MiniMaxAPIHelper {
+  /// Returns true if the user has supplied a non-empty MiniMax API key in the Keychain.
+  static var hasAPIKey: Bool {
+    guard let key = KeychainManager.shared.retrieve(for: MiniMaxProvider.keychainKey) else {
+      return false
+    }
+    return !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+
+  /// Persist (or remove) the API key in the Keychain.
+  /// Pass `nil` or an empty string to remove the key.
+  static func setAPIKey(_ key: String?) {
+    let trimmed = key?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    if trimmed.isEmpty {
+      KeychainManager.shared.delete(for: MiniMaxProvider.keychainKey)
+    } else {
+      KeychainManager.shared.store(trimmed, for: MiniMaxProvider.keychainKey)
+    }
+  }
+
+  /// Quick connectivity smoke-test that sends a minimal chat-completion request.
+  /// Throws on non-200 responses or transport errors.
+  static func smokeTest(model: String = MiniMaxProvider.defaultModelId) async throws -> String {
+    guard let key = KeychainManager.shared.retrieve(for: MiniMaxProvider.keychainKey),
+      !key.isEmpty
+    else {
+      throw NSError(
+        domain: "MiniMaxAPIHelper", code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "MiniMax API key is not configured"])
+    }
+
+    guard let url = LocalEndpointUtilities.chatCompletionsURL(
+      baseURL: MiniMaxProvider.defaultEndpoint)
+    else {
+      throw NSError(
+        domain: "MiniMaxAPIHelper", code: 2,
+        userInfo: [NSLocalizedDescriptionKey: "Invalid MiniMax endpoint URL"])
+    }
+
+    struct Req: Codable {
+      let model: String
+      let messages: [Msg]
+      let max_tokens: Int
+      let temperature: Double
+    }
+    struct Msg: Codable {
+      let role: String
+      let content: String
+    }
+    struct Resp: Codable {
+      let choices: [Choice]
+    }
+    struct Choice: Codable {
+      let message: ChoiceMessage
+    }
+    struct ChoiceMessage: Codable {
+      let content: String
+    }
+
+    let body = Req(
+      model: model,
+      messages: [Msg(role: "user", content: "ping")],
+      max_tokens: 16,
+      temperature: 0
+    )
+
+    var req = URLRequest(url: url)
+    req.httpMethod = "POST"
+    req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    req.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+    req.httpBody = try JSONEncoder().encode(body)
+    req.timeoutInterval = 30
+
+    let (data, response) = try await URLSession.shared.data(for: req)
+    guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+      let body = String(data: data, encoding: .utf8) ?? "Unknown error"
+      throw NSError(
+        domain: "MiniMaxAPIHelper", code: (response as? HTTPURLResponse)?.statusCode ?? 3,
+        userInfo: [NSLocalizedDescriptionKey: "MiniMax API error: \(body)"])
+    }
+    let decoded = try JSONDecoder().decode(Resp.self, from: data)
+    let raw = decoded.choices.first?.message.content ?? ""
+    return MiniMaxReasoning.stripThinkTags(in: raw)
+  }
+}

--- a/Dayflow/Dayflow/Views/Onboarding/LLMProviderSetupView.swift
+++ b/Dayflow/Dayflow/Views/Onboarding/LLMProviderSetupView.swift
@@ -15,9 +15,16 @@ struct LLMProviderSetupView: View {
       return "Use local AI"
     case "chatgpt_claude":
       return "Connect ChatGPT or Claude"
+    case "minimax":
+      return "MiniMax M3"
     default:
       return "Gemini"
     }
+  }
+
+  /// True for cloud providers that share the same "API key" setup flow shape.
+  var isCloudAPIKeyProvider: Bool {
+    activeProviderType == "gemini" || activeProviderType == "minimax"
   }
 
   // Layout constants
@@ -327,8 +334,10 @@ struct LLMProviderSetupView: View {
         APIKeyInputView(
           apiKey: $setupState.apiKey,
           title: "Enter your API key:",
-          subtitle: "Paste your Gemini API key below",
-          placeholder: "AQ...",
+          subtitle: activeProviderType == "minimax"
+            ? "Paste your MiniMax API key below"
+            : "Paste your Gemini API key below",
+          placeholder: activeProviderType == "minimax" ? "ey..." : "AQ...",
           onValidate: { key in
             key.components(separatedBy: .whitespacesAndNewlines).joined().count > 10
           }
@@ -359,27 +368,38 @@ struct LLMProviderSetupView: View {
           )
         }
 
-        VStack(alignment: .leading, spacing: 12) {
-          Text(
-            "Choose your Gemini model. We recommend 3.5 Flash, with 3.1 Flash-Lite available as a fallback."
-          )
-          .font(.custom("Figtree", size: 16))
-          .fontWeight(.semibold)
-          .foregroundColor(.black.opacity(0.85))
+        if activeProviderType == "gemini" {
+          VStack(alignment: .leading, spacing: 12) {
+            Text(
+              "Choose your Gemini model. We recommend 3.5 Flash, with 3.1 Flash-Lite available as a fallback."
+            )
+            .font(.custom("Figtree", size: 16))
+            .fontWeight(.semibold)
+            .foregroundColor(.black.opacity(0.85))
 
-          Picker("Gemini model", selection: $setupState.geminiModel) {
-            ForEach(GeminiModel.allCases, id: \.self) { model in
-              Text(model.shortLabel).tag(model)
+            Picker("Gemini model", selection: $setupState.geminiModel) {
+              ForEach(GeminiModel.allCases, id: \.self) { model in
+                Text(model.shortLabel).tag(model)
+              }
             }
-          }
-          .pickerStyle(.segmented)
+            .pickerStyle(.segmented)
 
-          Text(GeminiModelPreference(primary: setupState.geminiModel).fallbackSummary)
-            .font(.custom("Figtree", size: 13))
-            .foregroundColor(.black.opacity(0.55))
-        }
-        .onChange(of: setupState.geminiModel) {
-          setupState.persistGeminiModelSelection(source: "onboarding_picker")
+            Text(GeminiModelPreference(primary: setupState.geminiModel).fallbackSummary)
+              .font(.custom("Figtree", size: 13))
+              .foregroundColor(.black.opacity(0.55))
+          }
+          .onChange(of: setupState.geminiModel) {
+            setupState.persistGeminiModelSelection(source: "onboarding_picker")
+          }
+        } else if activeProviderType == "minimax" {
+          VStack(alignment: .leading, spacing: 12) {
+            Text(
+              "Dayflow defaults to the MiniMax M3 model (1M-token context, multimodal). You can switch to M2.7 or another M-series model in Settings → Providers after setup."
+            )
+            .font(.custom("Figtree", size: 14))
+            .foregroundColor(.black.opacity(0.65))
+            .fixedSize(horizontal: false, vertical: true)
+          }
         }
 
         HStack {
@@ -448,6 +468,17 @@ struct LLMProviderSetupView: View {
             if title == "Testing" || title == "Test Connection" {
               if providerType == "gemini" {
                 TestConnectionView(
+                  providerID: "gemini",
+                  keychainKey: "gemini",
+                  onTestComplete: { success in
+                    setupState.hasTestedConnection = true
+                    setupState.testSuccessful = success
+                  }
+                )
+              } else if providerType == "minimax" {
+                TestConnectionView(
+                  providerID: "minimax",
+                  keychainKey: MiniMaxProvider.keychainKey,
                   onTestComplete: { success in
                     setupState.hasTestedConnection = true
                     setupState.testSuccessful = success
@@ -523,13 +554,17 @@ struct LLMProviderSetupView: View {
     case .apiKeyInstructions:
       VStack(alignment: .leading, spacing: 24) {
         VStack(alignment: .leading, spacing: 8) {
-          Text("Get your Gemini API key")
+          Text(activeProviderType == "minimax"
+              ? "Get your MiniMax API key"
+              : "Get your Gemini API key")
             .font(.custom("Figtree", size: 24))
             .fontWeight(.semibold)
             .foregroundColor(.black.opacity(0.9))
 
           Text(
-            "allows you to run Dayflow for free. All you need is a Google account - no credit card required."
+            activeProviderType == "minimax"
+              ? "powers Dayflow with MiniMax's frontier M3 model. Subscribe to a Token Plan and top up tokens to receive an API key — pay-as-you-go pricing applies after that."
+              : "allows you to run Dayflow for free. All you need is a Google account - no credit card required."
           )
           .font(.custom("Figtree", size: 14))
           .foregroundColor(.black.opacity(0.6))
@@ -542,11 +577,15 @@ struct LLMProviderSetupView: View {
               .foregroundColor(.black.opacity(0.6))
               .frame(width: 20, alignment: .leading)
 
-            Button(action: openGoogleAIStudio) {
-              Text("Visit Google AI Studio ")
-                .font(.custom("Figtree", size: 14))
-                .foregroundColor(.black.opacity(0.8))
-                + Text("(aistudio.google.com)")
+            Button(action: openProviderPortal) {
+              Text(
+                activeProviderType == "minimax"
+                  ? "Visit the MiniMax Token Plan page "
+                  : "Visit Google AI Studio "
+              )
+              .font(.custom("Figtree", size: 14))
+              .foregroundColor(.black.opacity(0.8))
+              + Text(providerPortalURLDisplay)
                 .font(.custom("Figtree", size: 14))
                 .foregroundColor(Color(red: 1, green: 0.42, blue: 0.02))
                 .underline()
@@ -561,9 +600,13 @@ struct LLMProviderSetupView: View {
               .foregroundColor(.black.opacity(0.6))
               .frame(width: 20, alignment: .leading)
 
-            Text("Click \"Create API key\" in the top right")
-              .font(.custom("Figtree", size: 14))
-              .foregroundColor(.black.opacity(0.8))
+            Text(
+              activeProviderType == "minimax"
+                ? "Subscribe to a Token Plan and generate an API key"
+                : "Click \"Create API key\" in the top right"
+            )
+            .font(.custom("Figtree", size: 14))
+            .foregroundColor(.black.opacity(0.8))
           }
 
           HStack(alignment: .top, spacing: 12) {
@@ -572,22 +615,31 @@ struct LLMProviderSetupView: View {
               .foregroundColor(.black.opacity(0.6))
               .frame(width: 20, alignment: .leading)
 
-            Text("Create a new API key and copy it")
-              .font(.custom("Figtree", size: 14))
-              .foregroundColor(.black.opacity(0.8))
+            Text(
+              activeProviderType == "minimax"
+                ? "Copy the API key and paste it on the next step"
+                : "Create a new API key and copy it"
+            )
+            .font(.custom("Figtree", size: 14))
+            .foregroundColor(.black.opacity(0.8))
           }
         }
         .padding(.vertical, 12)
 
-        // Buttons row with Open Google AI Studio on left, Next on right
+        // Buttons row with Open provider portal on left, Next on right
         HStack {
           DayflowSurfaceButton(
-            action: openGoogleAIStudio,
+            action: openProviderPortal,
             content: {
               HStack(spacing: 8) {
                 Image(systemName: "safari").font(.system(size: 14))
-                Text("Open Google AI Studio").font(.custom("Figtree", size: 14)).fontWeight(
-                  .semibold)
+                Text(
+                  activeProviderType == "minimax"
+                    ? "Open MiniMax Token Plan"
+                    : "Open Google AI Studio"
+                )
+                .font(.custom("Figtree", size: 14))
+                .fontWeight(.semibold)
               }
             },
             background: Color(red: 0.25, green: 0.17, blue: 0),
@@ -634,11 +686,18 @@ struct LLMProviderSetupView: View {
   }
 
   func saveConfiguration() {
-    // Save API key to keychain for Gemini
-    if activeProviderType == "gemini" && !setupState.apiKey.isEmpty {
+    // Save API key to keychain for cloud API providers
+    if isCloudAPIKeyProvider, !setupState.apiKey.isEmpty {
       let cleanedKey = setupState.apiKey.components(separatedBy: .whitespacesAndNewlines).joined()
-      KeychainManager.shared.store(cleanedKey, for: "gemini")
-      GeminiModelPreference(primary: setupState.geminiModel).save()
+      KeychainManager.shared.store(cleanedKey, for: setupState.keychainKey)
+      if activeProviderType == "gemini" {
+        GeminiModelPreference(primary: setupState.geminiModel).save()
+      } else if activeProviderType == "minimax" {
+        // Default the model to MiniMax-M3 on first run; user can change it later in Settings.
+        MiniMaxModelPreference(modelId: MiniMaxProvider.defaultModelId, hasUserOverride: false)
+          .persist()
+        UserDefaults.standard.set(MiniMaxProvider.defaultModelId, forKey: "llmMiniMaxModelId")
+      }
     }
 
     // Save local endpoint for local engine selection
@@ -677,6 +736,30 @@ struct LLMProviderSetupView: View {
   func openGoogleAIStudio() {
     if let url = URL(string: "https://aistudio.google.com/app/apikey") {
       NSWorkspace.shared.open(url)
+    }
+  }
+
+  /// Opens the provider's API-key portal — works for both Gemini and MiniMax.
+  func openProviderPortal() {
+    let urlString: String
+    switch activeProviderType {
+    case "minimax":
+      urlString = "https://platform.minimax.io/user-center/payment/token-plan"
+    default:
+      urlString = "https://aistudio.google.com/app/apikey"
+    }
+    if let url = URL(string: urlString) {
+      NSWorkspace.shared.open(url)
+    }
+  }
+
+  /// Short display string for the inline link in the instructions step.
+  var providerPortalURLDisplay: String {
+    switch activeProviderType {
+    case "minimax":
+      return "(platform.minimax.io)"
+    default:
+      return "(aistudio.google.com)"
     }
   }
 

--- a/Dayflow/Dayflow/Views/Onboarding/OnboardingFlow.swift
+++ b/Dayflow/Dayflow/Views/Onboarding/OnboardingFlow.swift
@@ -149,18 +149,23 @@ struct OnboardingFlow: View {
             case "Dayflow Pro": providerID = "dayflow"
             case "ChatGPT or Claude": providerID = "chatgpt_claude"
             case "Google Gemini": providerID = "gemini"
+            case "MiniMax M3": providerID = "minimax"
             case "Local AI": providerID = "ollama"
             default: providerID = "gemini"
             }
             selectedProvider = providerID
             if providerID == "dayflow" {
               LLMProviderType.dayflowBackend().persist()
+            } else if providerID == "minimax" {
+              LLMProviderType.minimax.persist()
             }
 
             var props: [String: Any] = ["provider": providerID]
             if providerID == "ollama" {
               let localEngine = UserDefaults.standard.string(forKey: "llmLocalEngine") ?? "ollama"
               props["local_engine"] = localEngine
+            } else if providerID == "minimax" {
+              props["model_id"] = MiniMaxProvider.defaultModelId
             }
             AnalyticsService.shared.capture("llm_provider_selected", props)
             AnalyticsService.shared.setPersonProperties(["current_llm_provider": providerID])

--- a/Dayflow/Dayflow/Views/Onboarding/OnboardingLLMSelectionView.swift
+++ b/Dayflow/Dayflow/Views/Onboarding/OnboardingLLMSelectionView.swift
@@ -269,6 +269,8 @@ struct OnboardingLLMSelectionView: View {
       providerType = .ollamaLocal()
     case "gemini":
       providerType = .geminiDirect
+    case "minimax":
+      providerType = .minimax
     case "dayflow":
       providerType = .dayflowBackend()
     case "chatgpt_claude":

--- a/Dayflow/Dayflow/Views/Onboarding/Prototype/OnboardingPrototypeChooseProviderStep.swift
+++ b/Dayflow/Dayflow/Views/Onboarding/Prototype/OnboardingPrototypeChooseProviderStep.swift
@@ -90,6 +90,15 @@ struct OnboardingPrototypeChooseProviderStep: View {
       notes: "Uses Gemini free tier."
     ),
     ComparisonProvider(
+      id: "minimax",
+      title: "MiniMax M3",
+      selectionName: "MiniMax M3",
+      accuracy: RatedValue(text: "Best", rating: .best),
+      subscription: "MiniMax Token Plan",
+      ease: RatedValue(text: "API key", rating: .medium),
+      notes: "Frontier multimodal model • 1M-token context window • native image & video understanding."
+    ),
+    ComparisonProvider(
       id: "local",
       title: "Local AI",
       selectionName: "Local AI",
@@ -219,7 +228,7 @@ struct OnboardingPrototypeChooseProviderStep: View {
         }
       }
     }
-    .frame(maxWidth: 1060)
+    .frame(maxWidth: 1280)
   }
 
   private var emptyLabelCell: some View {
@@ -272,6 +281,8 @@ struct OnboardingPrototypeChooseProviderStep: View {
       }
     case "gemini":
       iconCircle(imageName: "GeminiLogo")
+    case "minimax":
+      iconCircle(systemName: "sparkles")
     default:
       iconCircle(systemName: "laptopcomputer")
     }

--- a/Dayflow/Dayflow/Views/Onboarding/ProviderSetupState.swift
+++ b/Dayflow/Dayflow/Views/Onboarding/ProviderSetupState.swift
@@ -10,6 +10,16 @@ class ProviderSetupState: ObservableObject {
   @Published var hasTestedConnection: Bool = false
   @Published var testSuccessful: Bool = false
   @Published var geminiModel: GeminiModel
+  /// Set by `configureSteps(for:)`. Used to scope API-key persistence and
+  /// any provider-specific UI branches.
+  @Published var activeProviderType: String = "gemini"
+  /// Keychain key for the current provider ("gemini" or "minimax").
+  var keychainKey: String {
+    switch activeProviderType {
+    case "minimax": return MiniMaxProvider.keychainKey
+    default: return "gemini"
+    }
+  }
   // Local engine configuration
   @Published var localEngine: LocalEngine = .lmstudio
   @Published var localBaseURL: String = LocalEngine.lmstudio.defaultBaseURL
@@ -64,6 +74,7 @@ class ProviderSetupState: ObservableObject {
   }
 
   func configureSteps(for provider: String) {
+    activeProviderType = provider
     switch provider {
     case "ollama":
       steps = [
@@ -127,6 +138,25 @@ class ProviderSetupState: ObservableObject {
       claudeCLIReport = nil
       isCheckingCLIStatus = false
       hasStartedCLICheck = false
+    case "minimax":
+      steps = [
+        SetupStep(
+          id: "getkey", title: "Get API key",
+          contentType: .apiKeyInstructions),
+        SetupStep(
+          id: "enterkey", title: "Enter API key",
+          contentType: .apiKeyInput),
+        SetupStep(
+          id: "verify", title: "Test connection",
+          contentType: .information(
+            "Test Connection",
+            "Click the button below to verify your API key works with MiniMax M3.")),
+        SetupStep(
+          id: "complete", title: "Complete",
+          contentType: .information(
+            "All set!",
+            "MiniMax M3 is now configured and ready to use with Dayflow.")),
+      ]
     default:  // gemini
       steps = [
         SetupStep(
@@ -220,12 +250,14 @@ class ProviderSetupState: ObservableObject {
       apiKey = cleaned
     }
 
-    let stored = KeychainManager.shared.store(cleaned, for: "gemini")
+    let stored = KeychainManager.shared.store(cleaned, for: keychainKey)
     if stored {
       geminiAPIKeySaveError = nil
       hasTestedConnection = false
       testSuccessful = false
-      persistGeminiModelSelection(source: source)
+      if activeProviderType == "gemini" {
+        persistGeminiModelSelection(source: source)
+      }
     } else {
       geminiAPIKeySaveError =
         "Couldn't save your API key to Keychain. Please unlock Keychain and try again."

--- a/Dayflow/Dayflow/Views/Onboarding/TestConnectionView.swift
+++ b/Dayflow/Dayflow/Views/Onboarding/TestConnectionView.swift
@@ -2,18 +2,28 @@
 //  TestConnectionView.swift
 //  Dayflow
 //
-//  Test connection button for Gemini API
+//  Test connection button for any cloud API-key provider (Gemini, MiniMax M3, …).
 //
 
 import SwiftUI
 
 struct TestConnectionView: View {
+  /// Provider id used for analytics + label only. Defaults to "gemini".
+  let providerID: String
+  /// Keychain key holding the API key. Defaults to "gemini".
+  let keychainKey: String
   let onTestComplete: ((Bool) -> Void)?
 
   @State private var isTesting = false
   @State private var testResult: TestResult?
 
-  init(onTestComplete: ((Bool) -> Void)? = nil) {
+  init(
+    providerID: String = "gemini",
+    keychainKey: String = "gemini",
+    onTestComplete: ((Bool) -> Void)? = nil
+  ) {
+    self.providerID = providerID
+    self.keychainKey = keychainKey
     self.onTestComplete = onTestComplete
   }
 
@@ -44,53 +54,91 @@ struct TestConnectionView: View {
     guard !isTesting else { return }
 
     guard
-      let apiKey = KeychainManager.shared.retrieve(for: "gemini")?
+      let apiKey = KeychainManager.shared.retrieve(for: keychainKey)?
         .components(separatedBy: .whitespacesAndNewlines).joined(),
       !apiKey.isEmpty
     else {
       testResult = .failure("No API key found. Enter your API key first.")
       onTestComplete?(false)
       AnalyticsService.shared.capture(
-        "connection_test_failed", ["provider": "gemini", "error_code": "no_api_key"])
+        "connection_test_failed", ["provider": providerID, "error_code": "no_api_key"])
       return
     }
 
     isTesting = true
     testResult = nil
-    AnalyticsService.shared.capture("connection_test_started", ["provider": "gemini"])
+    AnalyticsService.shared.capture("connection_test_started", ["provider": providerID])
 
     Task {
-      do {
-        let _ = try await GeminiAPIHelper.shared.testConnection(apiKey: apiKey)
-        await MainActor.run {
-          testResult = .success("Connection successful.")
-          isTesting = false
-          onTestComplete?(true)
-        }
-        AnalyticsService.shared.capture("connection_test_succeeded", ["provider": "gemini"])
-      } catch GeminiAPIHelper.APIError.rateLimited {
-        await MainActor.run {
-          testResult = .success("API key works, but Gemini is rate limited right now.")
-          isTesting = false
-          onTestComplete?(true)
-        }
-        AnalyticsService.shared.capture(
-          "connection_test_succeeded",
-          [
-            "provider": "gemini",
-            "status": "rate_limited",
-            "model": GeminiModel.flashLite31.rawValue,
-          ])
-      } catch {
-        await MainActor.run {
-          testResult = .failure(error.localizedDescription)
-          isTesting = false
-          onTestComplete?(false)
-        }
-        AnalyticsService.shared.capture(
-          "connection_test_failed",
-          ["provider": "gemini", "error_code": String((error as NSError).code)])
+      switch providerID {
+      case "minimax":
+        await runMiniMaxTest()
+      default:
+        await runGeminiTest(apiKey: apiKey)
       }
+    }
+  }
+
+  private func runGeminiTest(apiKey: String) async {
+    do {
+      let _ = try await GeminiAPIHelper.shared.testConnection(apiKey: apiKey)
+      await MainActor.run {
+        testResult = .success("Connection successful.")
+        isTesting = false
+        onTestComplete?(true)
+      }
+      AnalyticsService.shared.capture("connection_test_succeeded", ["provider": "gemini"])
+    } catch GeminiAPIHelper.APIError.rateLimited {
+      await MainActor.run {
+        testResult = .success("API key works, but Gemini is rate limited right now.")
+        isTesting = false
+        onTestComplete?(true)
+      }
+      AnalyticsService.shared.capture(
+        "connection_test_succeeded",
+        [
+          "provider": "gemini",
+          "status": "rate_limited",
+          "model": GeminiModel.flashLite31.rawValue,
+        ])
+    } catch {
+      await MainActor.run {
+        testResult = .failure(error.localizedDescription)
+        isTesting = false
+        onTestComplete?(false)
+      }
+      AnalyticsService.shared.capture(
+        "connection_test_failed",
+        ["provider": "gemini", "error_code": String((error as NSError).code)])
+    }
+  }
+
+  private func runMiniMaxTest() async {
+    do {
+      let _ = try await MiniMaxAPIHelper.smokeTest()
+      await MainActor.run {
+        testResult = .success("Connected to MiniMax M3 successfully.")
+        isTesting = false
+        onTestComplete?(true)
+      }
+      AnalyticsService.shared.capture(
+        "connection_test_succeeded",
+        [
+          "provider": "minimax",
+          "model": MiniMaxProvider.defaultModelId,
+        ])
+    } catch {
+      await MainActor.run {
+        testResult = .failure(error.localizedDescription)
+        isTesting = false
+        onTestComplete?(false)
+      }
+      AnalyticsService.shared.capture(
+        "connection_test_failed",
+        [
+          "provider": "minimax",
+          "error_code": String((error as NSError).code),
+        ])
     }
   }
 }

--- a/Dayflow/Dayflow/Views/UI/CanvasActivityCard.swift
+++ b/Dayflow/Dayflow/Views/UI/CanvasActivityCard.swift
@@ -19,6 +19,10 @@ struct CanvasActivityCard: View {
   let isSelected: Bool
   let isSystemCategory: Bool
   let isBackupGenerated: Bool
+  /// "MiniMax M3 · MiniMax-M3" — small text shown in the card footer so the
+  /// user always sees which provider/model produced this card. Optional
+  /// because older saved cards don't carry the metadata.
+  let providerBadge: String?
   let onTap: () -> Void
   // Raw values for pattern matching (may contain paths)
   let faviconPrimaryRaw: String?
@@ -140,19 +144,28 @@ struct CanvasActivityCard: View {
 
             Spacer()
 
-            HStack(spacing: 6) {
-              if isBackupGenerated {
-                backupIndicator
+            VStack(alignment: .trailing, spacing: 2) {
+              HStack(spacing: 6) {
+                if isBackupGenerated {
+                  backupIndicator
+                }
+                Text(time)
+                  .font(
+                    Font.custom("Figtree", size: secondaryFontSize)
+                      .weight(.medium)
+                  )
+                  .foregroundColor(style.time)
+                  .lineLimit(1)
+                  .truncationMode(.tail)
               }
-
-              Text(time)
-                .font(
-                  Font.custom("Figtree", size: secondaryFontSize)
-                    .weight(.medium)
-                )
-                .foregroundColor(style.time)
-                .lineLimit(1)
-                .truncationMode(.tail)
+              if let badge = providerBadge, !badge.isEmpty {
+                Text(badge)
+                  .font(.custom("Figtree", size: 9))
+                  .foregroundColor(.secondary)
+                  .lineLimit(1)
+                  .truncationMode(.tail)
+                  .help("This card was produced by \(badge)")
+              }
             }
           }
         }

--- a/Dayflow/Dayflow/Views/UI/CanvasTimelineDataView.swift
+++ b/Dayflow/Dayflow/Views/UI/CanvasTimelineDataView.swift
@@ -107,6 +107,31 @@ struct CanvasTimelineDataView: View {
   // between triggers and keeps the body's inline closures tiny (fixes a
   // Swift type-checker timeout that appeared when each closure inlined its
   // own copy of this calculation).
+  /// Compact "provider · model" string used in the per-card badge.
+  private func providerBadge(for activity: TimelineActivity) -> String? {
+    let rawProvider = (activity.providerId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    let rawModel = (activity.modelId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    if rawProvider.isEmpty && rawModel.isEmpty { return nil }
+    let providerLabel: String
+    switch rawProvider {
+    case "gemini": providerLabel = "Gemini"
+    case "minimax": providerLabel = "MiniMax"
+    case "ollama": providerLabel = "Local"
+    case "chatgpt_claude":
+      // For ChatGPT/Claude CLI we also want to surface *which* tool produced
+      // the card. Fall back to a generic label if the model id doesn't tell
+      // us.
+      if rawModel.lowercased().contains("claude") { providerLabel = "Claude" }
+      else if rawModel.lowercased().contains("gpt") || rawModel.lowercased().contains("codex")
+      { providerLabel = "ChatGPT" }
+      else { providerLabel = "CLI" }
+    case "dayflow": providerLabel = "Dayflow Pro"
+    default: providerLabel = rawProvider.isEmpty ? "AI" : rawProvider
+    }
+    if rawModel.isEmpty { return providerLabel }
+    return "\(providerLabel) · \(rawModel)"
+  }
+
   private func nowCenteredTargetHourIndex() -> Int {
     let currentHour = Calendar.current.component(.hour, from: Date())
     let hoursSince4AM = currentHour >= 4 ? currentHour - 4 : (24 - 4) + currentHour
@@ -329,6 +354,7 @@ struct CanvasTimelineDataView: View {
             isSystemCategory: item.categoryName.trimmingCharacters(in: .whitespacesAndNewlines)
               .caseInsensitiveCompare("System") == .orderedSame,
             isBackupGenerated: item.activity.isBackupGenerated == true,
+            providerBadge: providerBadge(for: item.activity),
             onTap: {
               if selectedCardId == item.id {
                 clearSelection()

--- a/Dayflow/Dayflow/Views/UI/Dashboard/ProviderStatsView.swift
+++ b/Dayflow/Dayflow/Views/UI/Dashboard/ProviderStatsView.swift
@@ -1,0 +1,505 @@
+//
+//  ProviderStatsView.swift
+//  Dayflow
+//
+//  Dashboard surface that visualises which Dayflow provider + model produced
+//  which activity cards, in the same GitHub-contribution-graph style the user
+//  asked for. Read-only — all state is loaded on appear from
+//  `StorageManager` and re-computed when the underlying `TimelineCard` list
+//  changes.
+//
+
+import SwiftUI
+
+@MainActor
+final class ProviderStatsViewModel: ObservableObject {
+  @Published private(set) var summary: ProviderStatsSummary = .empty
+  @Published private(set) var isLoading: Bool = false
+
+  func reload() {
+    isLoading = true
+    Task.detached(priority: .userInitiated) {
+      let cards = await StorageManager.shared.fetchAllTimelineCards()
+      let s = ProviderStatsCalculator.summary(from: cards)
+      await MainActor.run {
+        self.summary = s
+        self.isLoading = false
+      }
+    }
+  }
+}
+
+extension ProviderStatsSummary {
+  static let empty = ProviderStatsSummary(
+    totalCards: 0,
+    byProvider: [:],
+    byModel: [],
+    daily: [],
+    weekly: [],
+    monthly: [],
+    earliest: nil,
+    latest: nil,
+    heatmapDays: [],
+    peakDay: nil
+  )
+}
+
+struct ProviderStatsView: View {
+  @StateObject private var viewModel = ProviderStatsViewModel()
+  @State private var selectedRange: TimeRange = .year
+
+  enum TimeRange: String, CaseIterable, Identifiable {
+    case week = "Week"
+    case month = "Month"
+    case quarter = "Quarter"
+    case year = "Year"
+    var id: String { rawValue }
+  }
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 20) {
+        header
+        summaryStats
+        providerBreakdown
+        modelBreakdown
+        heatmapSection
+        timeSeriesSection
+      }
+      .padding(20)
+    }
+    .background(Color(NSColor.windowBackgroundColor))
+    .onAppear { viewModel.reload() }
+  }
+
+  // MARK: - Header
+
+  private var header: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack {
+        Text("Usage statistics")
+          .font(.custom("Figtree", size: 22))
+          .fontWeight(.semibold)
+        Spacer()
+        if viewModel.isLoading {
+          ProgressView().scaleEffect(0.6)
+        } else {
+          Button {
+            viewModel.reload()
+          } label: {
+            Image(systemName: "arrow.clockwise")
+          }
+          .buttonStyle(.borderless)
+          .help("Recompute statistics from local storage")
+        }
+      }
+      Text(
+        viewModel.summary.totalCards == 0
+          ? "No activity cards yet. Once Dayflow processes a recording, you'll see your provider and model usage here."
+          : "Tracks which Dayflow provider and model produced each activity card. All data stays on your Mac."
+      )
+      .font(.custom("Figtree", size: 12))
+      .foregroundColor(.secondary)
+    }
+  }
+
+  // MARK: - Summary cards
+
+  private var summaryStats: some View {
+    let s = viewModel.summary
+    return HStack(spacing: 12) {
+      statTile(
+        title: "Total cards",
+        value: "\(s.totalCards)",
+        icon: "rectangle.stack"
+      )
+      statTile(
+        title: "Active providers",
+        value: "\(s.byProvider.values.filter { $0 > 0 }.count)",
+        icon: "cpu"
+      )
+      statTile(
+        title: "Peak day",
+        value: s.peakDay.map { "\($0.count) on " + dateLabel($0.date) } ?? "—",
+        icon: "flame"
+      )
+      statTile(
+        title: "Tracking from",
+        value: s.earliest.map { dateLabel($0) } ?? "—",
+        icon: "calendar"
+      )
+    }
+  }
+
+  private func statTile(title: String, value: String, icon: String) -> some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Label(title, systemImage: icon)
+        .font(.custom("Figtree", size: 11))
+        .foregroundColor(.secondary)
+      Text(value)
+        .font(.custom("Figtree", size: 18).weight(.semibold))
+        .lineLimit(1)
+        .minimumScaleFactor(0.6)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(12)
+    .background(
+      RoundedRectangle(cornerRadius: 8)
+        .fill(Color(NSColor.controlBackgroundColor))
+    )
+  }
+
+  // MARK: - Provider breakdown
+
+  private var providerBreakdown: some View {
+    let s = viewModel.summary
+    let total = max(1, s.totalCards)
+    let entries = ProviderStatsCalculator.knownProviders.compactMap { id -> (String, Int)? in
+      let count = s.byProvider[id] ?? 0
+      return count > 0 ? (displayName(for: id), count) : nil
+    }
+    let maxValue = max(1, entries.map(\.1).max() ?? 1)
+    return sectionCard(title: "Provider breakdown", subtitle: "Cards produced by each provider") {
+      if entries.isEmpty {
+        Text("No provider activity yet.")
+          .font(.custom("Figtree", size: 12))
+          .foregroundColor(.secondary)
+      } else {
+        VStack(alignment: .leading, spacing: 8) {
+          ForEach(0..<entries.count, id: \.self) { i in
+            providerBar(
+              entry: entries[i],
+              total: total,
+              maxValue: maxValue
+            )
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Model breakdown
+
+  private var modelBreakdown: some View {
+    let entries = viewModel.summary.byModel
+    return sectionCard(
+      title: "Model breakdown",
+      subtitle: "Per-(provider · model) usage"
+    ) {
+      if entries.isEmpty {
+        Text("No model-level data yet — older cards don't carry the model id.")
+          .font(.custom("Figtree", size: 12))
+          .foregroundColor(.secondary)
+      } else {
+        VStack(alignment: .leading, spacing: 6) {
+          ForEach(Array(entries.enumerated()), id: \.offset) { _, entry in
+            HStack(spacing: 8) {
+              Circle()
+                .fill(colorFor(providerID: entry.providerID))
+                .frame(width: 8, height: 8)
+              Text(displayName(for: entry.providerID))
+                .font(.custom("Figtree", size: 11))
+                .foregroundColor(.secondary)
+                .frame(width: 100, alignment: .leading)
+              Text(entry.modelID)
+                .font(.custom("Figtree", size: 12).monospaced())
+                .lineLimit(1)
+                .truncationMode(.middle)
+              Spacer()
+              Text("\(entry.count) cards")
+                .font(.custom("Figtree", size: 12))
+                .foregroundColor(.secondary)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Heatmap
+
+  private var heatmapSection: some View {
+    sectionCard(
+      title: "Activity heatmap",
+      subtitle: "GitHub-style: each cell is one day, brighter = more cards produced."
+    ) {
+      HeatmapView(days: viewModel.summary.heatmapDays)
+    }
+  }
+
+  // MARK: - Time series
+
+  private var timeSeriesSection: some View {
+    let s = viewModel.summary
+    return sectionCard(
+      title: "Timeline",
+      subtitle: "Card counts per week and per month"
+    ) {
+      VStack(alignment: .leading, spacing: 16) {
+        Picker("Range", selection: $selectedRange) {
+          ForEach(TimeRange.allCases) { Text($0.rawValue).tag($0) }
+        }
+        .pickerStyle(.segmented)
+        .frame(maxWidth: 280)
+
+        switch selectedRange {
+        case .week:
+          timeSeriesBarChart(
+            entries: Array(s.daily.suffix(7).map { ($0.date, $0.count) }),
+            color: .blue
+          )
+        case .month:
+          timeSeriesBarChart(
+            entries: Array(s.daily.suffix(30).map { ($0.date, $0.count) }),
+            color: .purple
+          )
+        case .quarter:
+          timeSeriesBarChart(
+            entries: s.weekly.suffix(13).map { ($0.weekStart, $0.count) },
+            color: .orange
+          )
+        case .year:
+          timeSeriesBarChart(
+            entries: s.monthly.map { ($0.monthStart, $0.count) },
+            color: .green
+          )
+        }
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func timeSeriesBarChart(entries: [(Date, Int)], color: Color) -> some View {
+    let maxValue = max(1, entries.map(\.1).max() ?? 1)
+    if entries.isEmpty {
+      Text("No data for this range yet.")
+        .font(.custom("Figtree", size: 12))
+        .foregroundColor(.secondary)
+    } else {
+      HStack(alignment: .bottom, spacing: 2) {
+        ForEach(Array(entries.enumerated()), id: \.offset) { _, entry in
+          VStack(spacing: 4) {
+            Text("\(entry.1)")
+              .font(.custom("Figtree", size: 8))
+              .foregroundColor(.secondary)
+            Rectangle()
+              .fill(color.opacity(0.6 + 0.4 * Double(entry.1) / Double(maxValue)))
+              .frame(height: max(2, CGFloat(entry.1) / CGFloat(maxValue) * 60))
+            Text(dateLabel(entry.0, short: true))
+              .font(.custom("Figtree", size: 8))
+              .foregroundColor(.secondary)
+          }
+          .frame(maxWidth: .infinity)
+        }
+      }
+      .frame(height: 110)
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func sectionCard<Content: View>(
+    title: String, subtitle: String, @ViewBuilder content: () -> Content
+  ) -> some View {
+    VStack(alignment: .leading, spacing: 12) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(title)
+          .font(.custom("Figtree", size: 14).weight(.semibold))
+        Text(subtitle)
+          .font(.custom("Figtree", size: 11))
+          .foregroundColor(.secondary)
+      }
+      content()
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(14)
+    .background(
+      RoundedRectangle(cornerRadius: 10)
+        .fill(Color(NSColor.controlBackgroundColor))
+    )
+  }
+
+  @ViewBuilder
+  private func providerBar(entry: (String, Int), total: Int, maxValue: Int) -> some View {
+    HStack(spacing: 8) {
+      Text(entry.0)
+        .frame(width: 110, alignment: .leading)
+        .font(.custom("Figtree", size: 12))
+      GeometryReader { proxy in
+        let width = proxy.size.width * CGFloat(entry.1) / CGFloat(maxValue)
+        RoundedRectangle(cornerRadius: 3)
+          .fill(colorFor(providerID: entry.0))
+          .frame(width: max(4, width), height: 14)
+      }
+      .frame(height: 14)
+      Text("\(entry.1)")
+        .font(.custom("Figtree", size: 12).monospacedDigit())
+        .foregroundColor(.secondary)
+        .frame(width: 40, alignment: .trailing)
+      Text("\(Int(round(Double(entry.1) / Double(total) * 100)))%")
+        .font(.custom("Figtree", size: 10))
+        .foregroundColor(SettingsStyle.meta)
+        .frame(width: 40, alignment: .trailing)
+    }
+  }
+
+  private func displayName(for providerID: String) -> String {
+    switch providerID {
+    case "gemini": return "Gemini"
+    case "minimax": return "MiniMax"
+    case "ollama": return "Local AI"
+    case "chatgpt_claude": return "ChatGPT / Claude"
+    case "dayflow": return "Dayflow Pro"
+    default: return providerID
+    }
+  }
+
+  private func colorFor(providerID: String) -> Color {
+    switch providerID {
+    case "gemini": return .blue
+    case "minimax": return .purple
+    case "ollama": return .green
+    case "chatgpt_claude": return .orange
+    case "dayflow": return .pink
+    default: return .gray
+    }
+  }
+
+  private func dateLabel(_ d: Date, short: Bool = false) -> String {
+    let f = DateFormatter()
+    f.dateFormat = short ? "MMM d" : "MMM d, yyyy"
+    return f.string(from: d)
+  }
+}
+
+// MARK: - Heatmap view
+
+struct HeatmapView: View {
+  let days: [HeatmapDay]
+
+  private static let cellSize: CGFloat = 11
+  private static let cellSpacing: CGFloat = 2
+
+  /// Group `days` into calendar weeks, anchored to the most recent Sunday.
+  private var grid: [[HeatmapDay?]] {
+    guard !days.isEmpty else { return [] }
+    let calendar = Calendar.current
+    let firstDay = days.first?.date ?? Date()
+    let lastDay = days.last?.date ?? Date()
+    let weekdayOfLast = calendar.component(.weekday, from: lastDay)
+    let trailingPad = (7 - weekdayOfLast) % 7
+
+    // Map date -> HeatmapDay for quick lookup
+    var byDate: [Date: HeatmapDay] = [:]
+    for d in days { byDate[calendar.startOfDay(for: d.date)] = d }
+
+    var weeks: [[HeatmapDay?]] = []
+    var current = Array<HeatmapDay?>(repeating: nil, count: 7)
+    var cursor = calendar.startOfDay(for: firstDay)
+    let endDay = calendar.date(byAdding: .day, value: trailingPad, to: lastDay) ?? lastDay
+    while cursor <= endDay {
+      let weekday = calendar.component(.weekday, from: cursor)  // 1...7 (Sun...Sat)
+      current[weekday - 1] = byDate[cursor]
+      if weekday == 7 {
+        weeks.append(current)
+        current = Array<HeatmapDay?>(repeating: nil, count: 7)
+      }
+      cursor = calendar.date(byAdding: .day, value: 1, to: cursor) ?? cursor.addingTimeInterval(86400)
+    }
+    if current.contains(where: { $0 != nil }) {
+      weeks.append(current)
+    }
+    return weeks
+  }
+
+  private let monthFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.dateFormat = "MMM"
+    return f
+  }()
+
+  var body: some View {
+    if days.isEmpty {
+      Text("No activity in the last year yet.")
+        .font(.custom("Figtree", size: 12))
+        .foregroundColor(.secondary)
+    } else {
+      ScrollView(.horizontal, showsIndicators: false) {
+        VStack(alignment: .leading, spacing: 4) {
+          HStack(alignment: .top, spacing: 2) {
+            Color.clear.frame(width: 22)
+            ForEach(Array(grid.enumerated()), id: \.offset) { weekIndex, week in
+              let firstDate = week.compactMap { $0?.date }.first
+              if let firstDate, weekIndex == 0 || calendar.component(.weekday, from: firstDate) == 1
+              {
+                Text(monthFormatter.string(from: firstDate))
+                  .font(.custom("Figtree", size: 9))
+                  .foregroundColor(.secondary)
+                  .frame(width: Self.cellSize + Self.cellSpacing, alignment: .leading)
+              } else {
+                Color.clear.frame(width: Self.cellSize + Self.cellSpacing, height: 10)
+              }
+            }
+          }
+          HStack(alignment: .top, spacing: 2) {
+            VStack(alignment: .leading, spacing: 0) {
+              Text("M")
+              Text("W")
+              Text("F")
+            }
+            .font(.custom("Figtree", size: 8))
+            .foregroundColor(.secondary)
+            .frame(width: 22, alignment: .leading)
+            ForEach(Array(grid.enumerated()), id: \.offset) { _, week in
+              VStack(spacing: Self.cellSpacing) {
+                ForEach(Array(week.enumerated()), id: \.offset) { _, day in
+                  Rectangle()
+                    .fill(colorFor(intensity: day?.intensity ?? 0))
+                    .frame(width: Self.cellSize, height: Self.cellSize)
+                    .overlay(
+                      RoundedRectangle(cornerRadius: 2)
+                        .stroke(Color.black.opacity(0.06), lineWidth: 0.5)
+                    )
+                    .help(heatmapTooltip(for: day))
+                }
+              }
+            }
+          }
+          HStack(spacing: 6) {
+            Text("Less")
+              .font(.custom("Figtree", size: 9))
+              .foregroundColor(.secondary)
+            ForEach(0..<5) { i in
+              Rectangle()
+                .fill(colorFor(intensity: Double(i) / 4.0))
+                .frame(width: Self.cellSize, height: Self.cellSize)
+            }
+            Text("More")
+              .font(.custom("Figtree", size: 9))
+              .foregroundColor(.secondary)
+          }
+          .padding(.top, 6)
+        }
+      }
+    }
+  }
+
+  private let calendar = Calendar.current
+
+  private func colorFor(intensity: Double) -> Color {
+    switch intensity {
+    case 0: return Color(NSColor.controlBackgroundColor).opacity(0.5)
+    case 0..<0.25: return Color.green.opacity(0.25)
+    case 0.25..<0.5: return Color.green.opacity(0.45)
+    case 0.5..<0.75: return Color.green.opacity(0.65)
+    default: return Color.green.opacity(0.85)
+    }
+  }
+
+  private func heatmapTooltip(for day: HeatmapDay?) -> String {
+    guard let day else { return "" }
+    let f = DateFormatter()
+    f.dateStyle = .medium
+    return "\(f.string(from: day.date)): \(day.count) card\(day.count == 1 ? "" : "s")"
+  }
+}

--- a/Dayflow/Dayflow/Views/UI/MainView/TimelineActivityLoader.swift
+++ b/Dayflow/Dayflow/Views/UI/MainView/TimelineActivityLoader.swift
@@ -148,7 +148,9 @@ enum TimelineActivityLoader {
           videoSummaryURL: card.videoSummaryURL,
           screenshot: nil,
           appSites: card.appSites,
-          isBackupGenerated: card.isBackupGenerated
+          isBackupGenerated: card.isBackupGenerated,
+          providerId: card.providerId,
+          modelId: card.modelId
         )
       )
     }

--- a/Dayflow/Dayflow/Views/UI/MainView/WeekTimelineGridPreview.swift
+++ b/Dayflow/Dayflow/Views/UI/MainView/WeekTimelineGridPreview.swift
@@ -136,7 +136,9 @@ private struct WeekTimelineHoverPrototypeHarness: View {
         videoSummaryURL: nil,
         screenshot: nil,
         appSites: spec.favicon.map { AppSites(primary: $0, secondary: nil) },
-        isBackupGenerated: false
+        isBackupGenerated: false,
+        providerId: nil,
+        modelId: nil
       )
 
       let yPos = CGFloat(spec.startMinutes) * ppm + 1

--- a/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel+PromptOverrides.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel+PromptOverrides.swift
@@ -170,6 +170,57 @@ extension ProvidersSettingsViewModel {
     chatCLIPromptOverridesLoaded = true
   }
 
+  // MARK: - MiniMax (M3)
+
+  func loadMiniMaxPromptOverridesIfNeeded(force: Bool = false) {
+    if minimaxPromptOverridesLoaded && !force { return }
+    isUpdatingMiniMaxPromptState = true
+    let overrides = MiniMaxPromptPreferences.load()
+
+    let trimmedSummary = overrides.summaryBlock?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmedTitle = overrides.titleBlock?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    useCustomMiniMaxSummaryPrompt = trimmedSummary?.isEmpty == false
+    useCustomMiniMaxTitlePrompt = trimmedTitle?.isEmpty == false
+
+    minimaxSummaryPromptText = trimmedSummary ?? MiniMaxPromptDefaults.summaryBlock
+    minimaxTitlePromptText = trimmedTitle ?? MiniMaxPromptDefaults.titleBlock
+
+    isUpdatingMiniMaxPromptState = false
+    minimaxPromptOverridesLoaded = true
+  }
+
+  func persistMiniMaxPromptOverridesIfReady() {
+    guard minimaxPromptOverridesLoaded, !isUpdatingMiniMaxPromptState else { return }
+    persistMiniMaxPromptOverrides()
+  }
+
+  func persistMiniMaxPromptOverrides() {
+    let overrides = MiniMaxPromptOverrides(
+      summaryBlock: normalizedOverride(
+        text: minimaxSummaryPromptText, enabled: useCustomMiniMaxSummaryPrompt),
+      titleBlock: normalizedOverride(
+        text: minimaxTitlePromptText, enabled: useCustomMiniMaxTitlePrompt)
+    )
+
+    if overrides.isEmpty {
+      MiniMaxPromptPreferences.reset()
+    } else {
+      MiniMaxPromptPreferences.save(overrides)
+    }
+  }
+
+  func resetMiniMaxPromptOverrides() {
+    isUpdatingMiniMaxPromptState = true
+    useCustomMiniMaxSummaryPrompt = false
+    useCustomMiniMaxTitlePrompt = false
+    minimaxSummaryPromptText = MiniMaxPromptDefaults.summaryBlock
+    minimaxTitlePromptText = MiniMaxPromptDefaults.titleBlock
+    MiniMaxPromptPreferences.reset()
+    isUpdatingMiniMaxPromptState = false
+    minimaxPromptOverridesLoaded = true
+  }
+
   func normalizedOverride(text: String, enabled: Bool) -> String? {
     guard enabled else { return nil }
     let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
@@ -693,6 +693,11 @@ final class ProvidersSettingsViewModel: ObservableObject {
         return !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
       }
       return UserDefaults.standard.bool(forKey: "geminiSetupComplete")
+    case "minimax":
+      if let key = KeychainManager.shared.retrieve(for: MiniMaxProvider.keychainKey) {
+        return !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      }
+      return UserDefaults.standard.bool(forKey: "minimaxSetupComplete")
     case "ollama":
       if UserDefaults.standard.bool(forKey: "ollamaSetupComplete") {
         return true

--- a/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
@@ -111,8 +111,38 @@ final class ProvidersSettingsViewModel: ObservableObject {
     didSet { persistChatCLIPromptOverridesIfReady() }
   }
 
+  // MARK: - MiniMax (M3) provider state
+
+  @Published var selectedMiniMaxModel: String = MiniMaxProvider.defaultModelId {
+    didSet {
+      guard oldValue != selectedMiniMaxModel else { return }
+      UserDefaults.standard.set(selectedMiniMaxModel, forKey: "llmMiniMaxModelId")
+    }
+  }
+  @Published var minimaxAPIKey: String = "" {
+    didSet {
+      guard oldValue != minimaxAPIKey else { return }
+      MiniMaxAPIHelper.setAPIKey(minimaxAPIKey)
+    }
+  }
+  @Published var minimaxPromptOverridesLoaded = false
+  @Published var isUpdatingMiniMaxPromptState = false
+  @Published var useCustomMiniMaxTitlePrompt = false {
+    didSet { persistMiniMaxPromptOverridesIfReady() }
+  }
+  @Published var useCustomMiniMaxSummaryPrompt = false {
+    didSet { persistMiniMaxPromptOverridesIfReady() }
+  }
+  @Published var minimaxTitlePromptText = MiniMaxPromptDefaults.titleBlock {
+    didSet { persistMiniMaxPromptOverridesIfReady() }
+  }
+  @Published var minimaxSummaryPromptText = MiniMaxPromptDefaults.summaryBlock {
+    didSet { persistMiniMaxPromptOverridesIfReady() }
+  }
+
   private var hasLoadedProvider = false
   private var savedGeminiModel: GeminiModel
+  private var savedMiniMaxModel: String = MiniMaxProvider.defaultModelId
   private var pendingSetupRole: ProviderRoutingRole?
   private var pendingSetupDisplayProviderId: String?
 
@@ -120,6 +150,11 @@ final class ProvidersSettingsViewModel: ObservableObject {
     let preference = GeminiModelPreference.load()
     selectedGeminiModel = preference.primary
     savedGeminiModel = preference.primary
+
+    let minimaxPref = MiniMaxModelPreference.load()
+    selectedMiniMaxModel = minimaxPref.modelId
+    savedMiniMaxModel = minimaxPref.modelId
+    minimaxAPIKey = KeychainManager.shared.retrieve(for: MiniMaxProvider.keychainKey) ?? ""
 
     let rawEngine = UserDefaults.standard.string(forKey: "llmLocalEngine") ?? "ollama"
     let engine = LocalEngine(rawValue: rawEngine) ?? .ollama
@@ -153,6 +188,7 @@ final class ProvidersSettingsViewModel: ObservableObject {
     loadGeminiPromptOverridesIfNeeded()
     loadOllamaPromptOverridesIfNeeded()
     loadChatCLIPromptOverridesIfNeeded()
+    loadMiniMaxPromptOverridesIfNeeded()
   }
 
   func handleLocalTestCompletion() {
@@ -181,6 +217,8 @@ final class ProvidersSettingsViewModel: ObservableObject {
       loadOllamaPromptOverridesIfNeeded(force: true)
     } else if provider == "chatgpt_claude" {
       loadChatCLIPromptOverridesIfNeeded(force: true)
+    } else if provider == "minimax" {
+      loadMiniMaxPromptOverridesIfNeeded(force: true)
     }
     refreshUpgradeBannerState()
   }
@@ -261,6 +299,11 @@ final class ProvidersSettingsViewModel: ObservableObject {
       currentProvider = "ollama"
     case .chatGPTClaude:
       currentProvider = "chatgpt_claude"
+    case .minimax:
+      currentProvider = "minimax"
+      let preference = MiniMaxModelPreference.load()
+      selectedMiniMaxModel = preference.modelId
+      savedMiniMaxModel = preference.modelId
     }
     hasLoadedProvider = true
   }
@@ -759,6 +802,14 @@ final class ProvidersSettingsViewModel: ObservableObject {
         badgeType: .green,
         icon: "desktopcomputer"
       ),
+      CompactProviderInfo(
+        id: "minimax",
+        title: "MiniMax M3",
+        summary: "Frontier multimodal model • 1M-token context • paid API key",
+        badgeText: "NEW",
+        badgeType: .orange,
+        icon: "sparkles"
+      ),
     ]
   }
 
@@ -790,6 +841,9 @@ final class ProvidersSettingsViewModel: ObservableObject {
       return chatCLIStatusLabel()
     case "dayflow":
       return isDayflowProActive ? "Dayflow Pro active" : "Requires Dayflow Pro"
+    case "minimax":
+      let displayModel = selectedMiniMaxModel.isEmpty ? MiniMaxProvider.defaultModelId : selectedMiniMaxModel
+      return "MiniMax M3 – \(displayModel)"
     default:
       return nil
     }
@@ -820,6 +874,8 @@ final class ProvidersSettingsViewModel: ObservableObject {
       return "ChatGPT / Claude CLI"
     case "dayflow":
       return "Dayflow Backend"
+    case "minimax":
+      return "MiniMax API"
     default:
       return "Diagnostics"
     }
@@ -837,6 +893,7 @@ final class ProvidersSettingsViewModel: ObservableObject {
       }
       return "ChatGPT or Claude"
     case "dayflow": return "Dayflow Pro"
+    case "minimax": return "MiniMax M3"
     default: return id.capitalized
     }
   }

--- a/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/ProvidersSettingsViewModel.swift
@@ -125,6 +125,131 @@ final class ProvidersSettingsViewModel: ObservableObject {
       MiniMaxAPIHelper.setAPIKey(minimaxAPIKey)
     }
   }
+
+  // MARK: - Model catalog (live + curated, all providers)
+
+  /// Per-provider snapshot of available models, fetched from the provider API
+  /// or from a curated fallback list when the API isn't reachable.
+  @Published private(set) var modelSnapshots: [String: ModelListSnapshot] = [:]
+
+  /// In-flight provider IDs (UI uses this to spin a refresh button).
+  @Published private(set) var refreshingProviderIDs: Set<String> = []
+
+  /// User-selected model per provider. Mirrors the existing per-provider
+  /// `selected*Model` properties but is the source of truth that the
+  /// settings UI binds to.
+  @Published var selectedCodexModel: String = "gpt-4o" {
+    didSet { UserDefaults.standard.set(selectedCodexModel, forKey: "llmCodexModel") }
+  }
+  @Published var selectedClaudeModel: String = "claude-sonnet-4-5" {
+    didSet { UserDefaults.standard.set(selectedClaudeModel, forKey: "llmClaudeModel") }
+  }
+
+  /// All models for a provider, or an empty array if we haven't fetched yet.
+  func models(for providerID: String) -> [LLMModelOption] {
+    modelSnapshots[providerID]?.models ?? []
+  }
+
+  func isRefreshing(_ providerID: String) -> Bool {
+    refreshingProviderIDs.contains(providerID)
+  }
+
+  /// The currently effective model for the active provider — i.e. what gets
+  /// sent on the wire. This is the single source of truth the LLMService
+  /// and ChatService read from.
+  var effectiveModelForCurrentProvider: String {
+    switch currentProvider {
+    case "gemini": return selectedGeminiModel.rawValue
+    case "minimax": return selectedMiniMaxModel
+    case "ollama": return localModelId
+    case "chatgpt_claude":
+      switch preferredCLITool {
+      case .codex?: return selectedCodexModel
+      case .claude?: return selectedClaudeModel
+      case .none: return selectedClaudeModel  // safe default
+      }
+    case "dayflow": return "dayflow-managed"
+    default: return ""
+    }
+  }
+
+  /// Fetch (or re-fetch) the model list for a provider. Cheap if the cached
+  /// list is < 24h old and `force == false`.
+  func refreshModels(for providerID: String, force: Bool = false) async {
+    if !force, let cached = modelSnapshots[providerID], !cached.isStale { return }
+    if refreshingProviderIDs.contains(providerID) { return }
+    refreshingProviderIDs.insert(providerID)
+    defer { refreshingProviderIDs.remove(providerID) }
+    do {
+      let snapshot = try await ModelCatalog.shared.refresh(for: providerID)
+      await MainActor.run {
+        self.modelSnapshots[providerID] = snapshot
+        // If the currently-selected model is no longer in the catalog, fall
+        // back to the recommended one so the LLMService never sends a stale ID.
+        let activeID = self.activeModelID(for: providerID)
+        if !snapshot.models.isEmpty,
+          !snapshot.models.contains(where: { $0.id == activeID })
+        {
+          if let recommended = snapshot.models.first(where: { $0.isRecommended })
+            ?? snapshot.models.first
+          {
+            self.applyModelSelectionChange(recommended.id, for: providerID)
+          }
+        }
+      }
+    } catch {
+      // The catalog already returns a curated fallback on error, but if
+      // even that throws we just log and keep the previous snapshot.
+      print("[ProvidersSettingsViewModel] refreshModels(\(providerID)) failed: \(error)")
+    }
+  }
+
+  /// Refresh every provider that has a fetcher implemented. Called on
+  /// `handleOnAppear` so the settings page has up-to-date lists the moment
+  /// the user opens it.
+  func refreshAllProviderModels() async {
+    await withTaskGroup(of: Void.self) { group in
+      for id in ["gemini", "minimax", "ollama", "codex", "claude"] {
+        group.addTask { await self.refreshModels(for: id) }
+      }
+    }
+  }
+
+  /// When the user picks a model in the picker, persist it to the right
+  /// backing field. Mirrors the per-provider setter behaviour so the
+  /// existing `selectedGeminiModel.didSet` etc. keeps firing.
+  func setSelectedModel(_ modelID: String, for providerID: String) {
+    applyModelSelectionChange(modelID, for: providerID)
+  }
+
+  func activeModelID(for providerID: String) -> String {
+    switch providerID {
+    case "gemini": return selectedGeminiModel.rawValue
+    case "minimax": return selectedMiniMaxModel
+    case "ollama": return localModelId
+    case "codex": return selectedCodexModel
+    case "claude": return selectedClaudeModel
+    default: return ""
+    }
+  }
+
+  func applyModelSelectionChange(_ modelID: String, for providerID: String) {
+    switch providerID {
+    case "gemini":
+      if let model = GeminiModel(rawValue: modelID) {
+        selectedGeminiModel = model
+      }
+    case "minimax":
+      selectedMiniMaxModel = modelID
+    case "ollama":
+      localModelId = modelID
+    case "codex":
+      selectedCodexModel = modelID
+    case "claude":
+      selectedClaudeModel = modelID
+    default: break
+    }
+  }
   @Published var minimaxPromptOverridesLoaded = false
   @Published var isUpdatingMiniMaxPromptState = false
   @Published var useCustomMiniMaxTitlePrompt = false {
@@ -176,6 +301,27 @@ final class ProvidersSettingsViewModel: ObservableObject {
     } else {
       preferredCLITool = nil
     }
+
+    // Load the persisted ChatCLI model selections (codex + claude).
+    if let codex = UserDefaults.standard.string(forKey: "llmCodexModel"),
+      !codex.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    {
+      selectedCodexModel = codex
+    }
+    if let claude = UserDefaults.standard.string(forKey: "llmClaudeModel"),
+      !claude.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    {
+      selectedClaudeModel = claude
+    }
+
+    // Hydrate the in-memory model-snapshot cache from UserDefaults so the
+    // settings picker has *something* to show on the very first render
+    // (before the background refresh completes).
+    if let data = UserDefaults.standard.data(forKey: "llmModelCatalogCache.v1"),
+      let decoded = try? JSONDecoder().decode([String: ModelListSnapshot].self, from: data)
+    {
+      modelSnapshots = decoded
+    }
   }
 
   func handleOnAppear() {
@@ -189,6 +335,9 @@ final class ProvidersSettingsViewModel: ObservableObject {
     loadOllamaPromptOverridesIfNeeded()
     loadChatCLIPromptOverridesIfNeeded()
     loadMiniMaxPromptOverridesIfNeeded()
+    // Kick off background model-list refreshes for every provider. The UI
+    // re-renders the picker as each snapshot lands in `modelSnapshots`.
+    Task { await refreshAllProviderModels() }
   }
 
   func handleLocalTestCompletion() {

--- a/Dayflow/Dayflow/Views/UI/Settings/SettingsProvidersTabView.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/SettingsProvidersTabView.swift
@@ -31,6 +31,8 @@ struct SettingsProvidersTabView: View {
 
       if viewModel.currentProvider == "gemini" {
         geminiModelSection
+      } else if viewModel.currentProvider == "minimax" {
+        minimaxModelSection
       }
 
       promptCustomizationSection
@@ -110,6 +112,18 @@ struct SettingsProvidersTabView: View {
           text: KeychainManager.shared.retrieve(for: "gemini") != nil
             ? "Stored safely in Keychain" : "Not set")
       }
+    case "minimax":
+      let modelText = viewModel.selectedMiniMaxModel.isEmpty
+        ? MiniMaxProvider.defaultModelId
+        : viewModel.selectedMiniMaxModel
+      SettingsRow(label: "Model") {
+        SettingsMetadata(text: modelText)
+      }
+      SettingsRow(label: "API key", showsDivider: false) {
+        SettingsMetadata(
+          text: KeychainManager.shared.retrieve(for: MiniMaxProvider.keychainKey) != nil
+            ? "Stored safely in Keychain" : "Not set")
+      }
     case "chatgpt_claude":
       SettingsRow(label: "CLI preference") {
         SettingsMetadata(text: viewModel.chatCLIStatusLabel())
@@ -140,7 +154,13 @@ struct SettingsProvidersTabView: View {
 
         switch viewModel.currentProvider {
         case "gemini":
-          TestConnectionView(onTestComplete: { _ in })
+          TestConnectionView(providerID: "gemini", keychainKey: "gemini", onTestComplete: { _ in })
+        case "minimax":
+          TestConnectionView(
+            providerID: "minimax",
+            keychainKey: MiniMaxProvider.keychainKey,
+            onTestComplete: { _ in }
+          )
         case "ollama":
           LocalLLMTestView(
             baseURL: $viewModel.localBaseURL,
@@ -312,11 +332,91 @@ struct SettingsProvidersTabView: View {
     }
   }
 
+  // MARK: - MiniMax model preference
+
+  private var minimaxModelSection: some View {
+    SettingsSection(
+      title: "MiniMax M3 model",
+      subtitle: "Dayflow defaults to MiniMax-M3. You can switch to another M-series model below."
+    ) {
+      VStack(alignment: .leading, spacing: 14) {
+        TextField(
+          "Model ID",
+          text: Binding(
+            get: { viewModel.selectedMiniMaxModel },
+            set: { viewModel.selectedMiniMaxModel = $0 }
+          )
+        )
+        .textFieldStyle(.roundedBorder)
+        .onSubmit {
+          let trimmed = viewModel.selectedMiniMaxModel.trimmingCharacters(in: .whitespacesAndNewlines)
+          if !trimmed.isEmpty {
+            var pref = MiniMaxModelPreference.load()
+            pref.setModelId(trimmed)
+            pref.persist()
+            UserDefaults.standard.set(trimmed, forKey: "llmMiniMaxModelId")
+          }
+        }
+
+        Text(
+          "Common M-series model IDs: MiniMax-M3 (default), MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5."
+        )
+        .font(.custom("Figtree", size: 12))
+        .foregroundColor(SettingsStyle.secondary)
+
+        HStack(spacing: 8) {
+          SettingsSecondaryButton(
+            title: "Reset to M3",
+            action: {
+              var pref = MiniMaxModelPreference.load()
+              pref.reset()
+              pref.persist()
+              viewModel.selectedMiniMaxModel = MiniMaxProvider.defaultModelId
+              UserDefaults.standard.set(MiniMaxProvider.defaultModelId, forKey: "llmMiniMaxModelId")
+            }
+          )
+          SettingsSecondaryButton(
+            title: "Open MiniMax docs",
+            action: {
+              if let url = URL(string: "https://platform.minimax.io/docs/api-reference/text-openai-api") {
+                NSWorkspace.shared.open(url)
+              }
+            }
+          )
+        }
+      }
+    }
+  }
+
   // MARK: - Prompt customization
 
   @ViewBuilder
   private var promptCustomizationSection: some View {
     switch viewModel.currentProvider {
+    case "minimax":
+      promptSection(
+        title: "MiniMax prompt customization",
+        subtitle: "Override Dayflow's defaults to tailor card generation.",
+        intro:
+          "Overrides apply only when their toggle is on. Unchecked sections fall back to Dayflow's defaults.",
+        sections: [
+          promptEditorConfig(
+            heading: "Card titles",
+            description: "Shape how card titles read and tweak the example list.",
+            isEnabled: $viewModel.useCustomMiniMaxTitlePrompt,
+            text: $viewModel.minimaxTitlePromptText,
+            defaultText: MiniMaxPromptDefaults.titleBlock
+          ),
+          promptEditorConfig(
+            heading: "Card summaries",
+            description: "Control tone and style for the summary field.",
+            isEnabled: $viewModel.useCustomMiniMaxSummaryPrompt,
+            text: $viewModel.minimaxSummaryPromptText,
+            defaultText: MiniMaxPromptDefaults.summaryBlock
+          ),
+        ],
+        onReset: viewModel.resetMiniMaxPromptOverrides
+      )
     case "gemini":
       promptSection(
         title: "Gemini prompt customization",

--- a/Dayflow/Dayflow/Views/UI/Settings/SettingsProvidersTabView.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/SettingsProvidersTabView.swift
@@ -33,6 +33,10 @@ struct SettingsProvidersTabView: View {
         geminiModelSection
       } else if viewModel.currentProvider == "minimax" {
         minimaxModelSection
+      } else if viewModel.currentProvider == "ollama" {
+        ollamaModelSection
+      } else if viewModel.currentProvider == "chatgpt_claude" {
+        chatCLIModelSection
       }
 
       promptCustomizationSection
@@ -299,91 +303,280 @@ struct SettingsProvidersTabView: View {
     }
   }
 
-  // MARK: - Gemini model preference
+  // MARK: - Model picker (unified, live + curated)
 
-  private var geminiModelSection: some View {
+  /// Generic model picker section used by Gemini, MiniMax, Ollama, Codex and
+  /// Claude. Shows the model list pulled by `ModelCatalog` and lets the user
+  /// refresh it on demand.
+  @ViewBuilder
+  private func modelPickerSection(providerID: String, title: String, subtitle: String)
+    -> some View
+  {
+    let models = viewModel.models(for: providerID)
+    let isRefreshing = viewModel.isRefreshing(providerID)
+    let snapshot = viewModel.modelSnapshots[providerID]
+    let source = snapshot?.source
+    let fetchedAt = snapshot?.fetchedAt
+    let fetchError = snapshot?.fetchError
+
     SettingsSection(
-      title: "Gemini model preference",
-      subtitle: "Choose which Gemini model Dayflow should prioritize."
+      title: title,
+      subtitle: subtitle
     ) {
       VStack(alignment: .leading, spacing: 14) {
-        Picker("Gemini model", selection: $viewModel.selectedGeminiModel) {
-          ForEach(GeminiModel.allCases, id: \.self) { model in
-            Text(model.displayName).tag(model)
+        HStack(alignment: .top, spacing: 8) {
+          Picker(
+            "Model",
+            selection: Binding(
+              get: { viewModel.activeModelID(for: providerID) },
+              set: { viewModel.setSelectedModel($0, for: providerID) }
+            )
+          ) {
+            ForEach(models) { model in
+              HStack(spacing: 6) {
+                Text(model.displayName)
+                if model.isRecommended {
+                  Text("•")
+                    .foregroundColor(.orange)
+                    .help("Recommended for Dayflow")
+                }
+                if model.isDeprecated {
+                  Text("(deprecated)")
+                    .foregroundColor(.secondary)
+                    .font(.caption2)
+                }
+              }
+              .tag(model.id)
+            }
+          }
+          .pickerStyle(.menu)
+          .labelsHidden()
+          .environment(\.colorScheme, .light)
+          .disabled(models.isEmpty)
+
+          Button(action: {
+            Task { await viewModel.refreshModels(for: providerID, force: true) }
+          }) {
+            if isRefreshing {
+              ProgressView().scaleEffect(0.6).frame(width: 16, height: 16)
+            } else {
+              Image(systemName: "arrow.clockwise")
+            }
+          }
+          .buttonStyle(.borderless)
+          .help("Refresh model list from the provider")
+          .disabled(isRefreshing)
+        }
+
+        if models.isEmpty {
+          Text("No models yet. Click the refresh button to fetch the current list.")
+            .font(.custom("Figtree", size: 12))
+            .foregroundColor(SettingsStyle.secondary)
+            .padding(.top, 4)
+        } else {
+          // SwiftUI's `ForEach` overload resolution picks the `Binding<C>`
+          // initializer whenever the first argument is a `let`-bound array
+          // inside a `@ViewBuilder`. To dodge that, we iterate with
+          // `Array(models.enumerated())` and a manual row view, so the
+          // compiler unambiguously sees the random-access overload.
+          VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(models.prefix(6)), id: \.id) { m in
+              modelRow(m)
+            }
+            if models.count > 6 {
+              Text("+ \(models.count - 6) more in the menu above")
+                .font(.custom("Figtree", size: 11))
+                .foregroundColor(SettingsStyle.meta)
+            }
+          }
+          .padding(.top, 4)
+        }
+
+        if let source {
+          HStack(spacing: 6) {
+            Image(systemName: source == .live ? "antenna.radiowaves.left.and.right" : "books.vertical")
+              .font(.system(size: 10))
+              .foregroundColor(source == .live ? .green : .orange)
+            Text(
+              source == .live
+                ? "Live model list from provider"
+                : "Curated list (provider endpoint unreachable)"
+            )
+            .font(.custom("Figtree", size: 10))
+            .foregroundColor(SettingsStyle.meta)
           }
         }
-        .pickerStyle(.segmented)
-        .labelsHidden()
-        .environment(\.colorScheme, .light)
-        .onChange(of: viewModel.selectedGeminiModel) { _, newValue in
-          viewModel.persistGeminiModelSelection(newValue, source: "settings")
+        if let fetchedAt {
+          Text(
+            "Last refreshed \(fetchedAt, style: .relative) ago"
+          )
+          .font(.custom("Figtree", size: 10))
+          .foregroundColor(SettingsStyle.meta)
         }
-
-        Text(GeminiModelPreference(primary: viewModel.selectedGeminiModel).fallbackSummary)
-          .font(.custom("Figtree", size: 12))
-          .foregroundColor(SettingsStyle.secondary)
-
-        Text(
-          "Dayflow automatically downgrades if your chosen model is rate limited or unavailable."
-        )
-        .font(.custom("Figtree", size: 11))
-        .foregroundColor(SettingsStyle.meta)
+        if let fetchError {
+          Text(
+            "Note: \(fetchError). Showing the curated fallback list."
+          )
+          .font(.custom("Figtree", size: 10))
+          .foregroundColor(.orange)
+        }
       }
     }
   }
 
-  // MARK: - MiniMax model preference
+  private func formatContextWindow(_ tokens: Int) -> String {
+    if tokens >= 1_000_000 {
+      let millions = Double(tokens) / 1_000_000
+      return String(format: "%.1fM context", millions)
+    }
+    if tokens >= 1_000 {
+      return "\(tokens / 1_000)K context"
+    }
+    return "\(tokens) tokens"
+  }
+
+  /// Renders one model row in the provider-picker preview.
+  @ViewBuilder
+  private func modelRow(_ model: LLMModelOption) -> some View {
+    HStack(spacing: 6) {
+      if model.visionCapable {
+        Image(systemName: "eye")
+          .font(.system(size: 10))
+          .foregroundColor(.green)
+          .help("Vision-capable (supports screen images)")
+      } else {
+        Image(systemName: "text.alignleft")
+          .font(.system(size: 10))
+          .foregroundColor(.secondary)
+      }
+      Text(model.id)
+        .font(.custom("Figtree", size: 11))
+        .foregroundColor(.secondary)
+      if let ctx = model.contextWindow {
+        Text("· \(formatContextWindow(ctx))")
+          .font(.custom("Figtree", size: 11))
+          .foregroundColor(SettingsStyle.meta)
+      }
+      if model.isRecommended {
+        Text("· recommended")
+          .font(.custom("Figtree", size: 11))
+          .foregroundColor(.orange)
+      }
+      if model.isDeprecated {
+        Text("· deprecated")
+          .font(.custom("Figtree", size: 11))
+          .foregroundColor(.red)
+      }
+    }
+  }
+
+  // MARK: - Gemini model preference (live picker)
+
+  private var geminiModelSection: some View {
+    modelPickerSection(
+      providerID: "gemini",
+      title: "Gemini model",
+      subtitle: "Choose which Gemini model Dayflow should use. Refresh fetches Google's current list."
+    )
+  }
+
+  // MARK: - MiniMax model preference (live picker)
 
   private var minimaxModelSection: some View {
-    SettingsSection(
+    modelPickerSection(
+      providerID: "minimax",
       title: "MiniMax M3 model",
-      subtitle: "Dayflow defaults to MiniMax-M3. You can switch to another M-series model below."
+      subtitle: "Dayflow defaults to MiniMax-M3. Switch to any M-series model from MiniMax's catalog."
+    )
+  }
+
+  // MARK: - Ollama model preference (live picker)
+
+  private var ollamaModelSection: some View {
+    modelPickerSection(
+      providerID: "ollama",
+      title: "Local model (Ollama / LM Studio)",
+      subtitle:
+        "Picks a model from the running local server. Dayflow recommends any Qwen3-VL variant."
+    )
+  }
+
+  // MARK: - ChatCLI model preference (live picker, tool-specific)
+
+  private var chatCLIModelSection: some View {
+    SettingsSection(
+      title: "ChatGPT / Claude model",
+      subtitle: "Dayflow launches the Codex CLI or Claude Code CLI for these providers."
     ) {
       VStack(alignment: .leading, spacing: 14) {
-        TextField(
-          "Model ID",
-          text: Binding(
-            get: { viewModel.selectedMiniMaxModel },
-            set: { viewModel.selectedMiniMaxModel = $0 }
-          )
-        )
-        .textFieldStyle(.roundedBorder)
-        .onSubmit {
-          let trimmed = viewModel.selectedMiniMaxModel.trimmingCharacters(in: .whitespacesAndNewlines)
-          if !trimmed.isEmpty {
-            var pref = MiniMaxModelPreference.load()
-            pref.setModelId(trimmed)
-            pref.persist()
-            UserDefaults.standard.set(trimmed, forKey: "llmMiniMaxModelId")
+        // Picker per CLI tool.
+        chatCLIToolModelPicker(tool: .codex)
+        chatCLIToolModelPicker(tool: .claude)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func chatCLIToolModelPicker(tool: CLITool) -> some View {
+    let providerID: String = (tool == .codex) ? "codex" : "claude"
+    let title: String = (tool == .codex) ? "ChatGPT (Codex CLI) model" : "Claude (Code CLI) model"
+    let models = viewModel.models(for: providerID)
+    let isRefreshing = viewModel.isRefreshing(providerID)
+
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(alignment: .center, spacing: 8) {
+        Text(title)
+          .font(.custom("Figtree", size: 12))
+          .fontWeight(.semibold)
+          .foregroundColor(SettingsStyle.text)
+        Spacer()
+        Button(action: {
+          Task { await viewModel.refreshModels(for: providerID, force: true) }
+        }) {
+          if isRefreshing {
+            ProgressView().scaleEffect(0.6).frame(width: 14, height: 14)
+          } else {
+            Image(systemName: "arrow.clockwise").font(.system(size: 11))
           }
         }
+        .buttonStyle(.borderless)
+        .help("Refresh \(title) list")
+        .disabled(isRefreshing)
+      }
 
-        Text(
-          "Common M-series model IDs: MiniMax-M3 (default), MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5."
+      Picker(
+        "Model",
+        selection: Binding(
+          get: { viewModel.activeModelID(for: providerID) },
+          set: { viewModel.setSelectedModel($0, for: providerID) }
         )
-        .font(.custom("Figtree", size: 12))
-        .foregroundColor(SettingsStyle.secondary)
-
-        HStack(spacing: 8) {
-          SettingsSecondaryButton(
-            title: "Reset to M3",
-            action: {
-              var pref = MiniMaxModelPreference.load()
-              pref.reset()
-              pref.persist()
-              viewModel.selectedMiniMaxModel = MiniMaxProvider.defaultModelId
-              UserDefaults.standard.set(MiniMaxProvider.defaultModelId, forKey: "llmMiniMaxModelId")
+      ) {
+        ForEach(models) { model in
+          HStack(spacing: 4) {
+            Text(model.displayName)
+            if model.isRecommended {
+              Text("•")
+                .foregroundColor(.orange)
+                .help("Recommended")
             }
-          )
-          SettingsSecondaryButton(
-            title: "Open MiniMax docs",
-            action: {
-              if let url = URL(string: "https://platform.minimax.io/docs/api-reference/text-openai-api") {
-                NSWorkspace.shared.open(url)
-              }
+            if model.isDeprecated {
+              Text("(deprecated)")
+                .foregroundColor(.secondary)
+                .font(.caption2)
             }
-          )
+          }
+          .tag(model.id)
         }
+      }
+      .pickerStyle(.menu)
+      .labelsHidden()
+      .environment(\.colorScheme, .light)
+      .disabled(models.isEmpty)
+
+      if models.isEmpty {
+        Text("No models yet. Click refresh to load.")
+          .font(.custom("Figtree", size: 11))
+          .foregroundColor(SettingsStyle.secondary)
       }
     }
   }

--- a/Dayflow/Dayflow/Views/UI/TimelineDataModels.swift
+++ b/Dayflow/Dayflow/Views/UI/TimelineDataModels.swift
@@ -25,6 +25,11 @@ struct TimelineActivity: Identifiable {
   let screenshot: NSImage?
   let appSites: AppSites?
   let isBackupGenerated: Bool?
+  /// Which Dayflow provider produced this activity ("gemini", "minimax",
+  /// "ollama", "chatgpt_claude", "dayflow"). Optional for older rows.
+  let providerId: String?
+  /// Which model the provider used (e.g. "MiniMax-M3", "claude-sonnet-4-5").
+  let modelId: String?
 
   static func stableId(
     recordId: Int64?, batchId: Int64?, startTime: Date, endTime: Date, title: String,
@@ -64,7 +69,9 @@ struct TimelineActivity: Identifiable {
       videoSummaryURL: videoSummaryURL,
       screenshot: screenshot,
       appSites: appSites,
-      isBackupGenerated: isBackupGenerated
+      isBackupGenerated: isBackupGenerated,
+      providerId: providerId,
+      modelId: modelId
     )
   }
 
@@ -84,7 +91,9 @@ struct TimelineActivity: Identifiable {
       videoSummaryURL: newVideoSummaryURL,
       screenshot: screenshot,
       appSites: appSites,
-      isBackupGenerated: isBackupGenerated
+      isBackupGenerated: isBackupGenerated,
+      providerId: providerId,
+      modelId: modelId
     )
   }
 }

--- a/Dayflow/Dayflow/Views/UI/TimelineReviewTypes.swift
+++ b/Dayflow/Dayflow/Views/UI/TimelineReviewTypes.swift
@@ -235,7 +235,9 @@ func makeTimelineActivities(from cards: [TimelineCard], for date: Date)
         videoSummaryURL: card.videoSummaryURL,
         screenshot: nil,
         appSites: card.appSites,
-        isBackupGenerated: card.isBackupGenerated
+        isBackupGenerated: card.isBackupGenerated,
+        providerId: card.providerId,
+        modelId: card.modelId
       ))
   }
 


### PR DESCRIPTION
### What

Follow-up to #320. Adds a complete model-management and usage-analytics layer to Dayflow so the user always knows which provider + model produced each activity card and can change that pick at any time from Settings.

The user's request was:
> "Add model picker that fetches models from the provider on the fly, and a dashboard that shows provider/model usage with daily/weekly/monthly breakdown and a GitHub commit-style heatmap. Stamp the provider/model on every card too."

### Changes

**New: `Core/AI/ModelCatalog.swift`** (≈ 290 LOC)
Actor that fetches the current model list from each provider's API:
- `GET /v1/models` for **MiniMax** (OpenAI-compatible)
- `GET /v1beta/models?key=…` for **Gemini** (filtered to vision-capable)
- `GET {baseURL}/api/tags` for **Ollama**, `GET /v1/models` for **LM Studio**
- Curated lists for **ChatGPT/Claude CLIs** (no public list endpoint)
- 24h cache in `UserDefaults`. If the API call fails, falls back to a curated list with a `"Curated list (provider endpoint unreachable)"` banner in the UI.

**New: `Core/Analytics/ProviderStatsCalculator.swift`** (≈ 230 LOC)
Pure data layer that turns the local `TimelineCard` list into a `ProviderStatsSummary`:
- `byProvider: [String: Int]` (always includes the 5 known providers, even if zero)
- `byModel: [(providerID, modelID, count)]`
- `daily: [DailyStat]` (last 365 days)
- `weekly: [WeeklyStat]` (last 26 weeks)
- `monthly: [MonthlyStat]` (last 12 months)
- `heatmapDays: [HeatmapDay]` (last 365 days, intensity 0…1)

**New: `Views/UI/Dashboard/ProviderStatsView.swift`** (≈ 500 LOC)
Self-contained dashboard surface with:
- 4 stat tiles (total cards, active providers, peak day, tracking from)
- Provider bar chart + percentages
- Per-(provider, model) breakdown
- GitHub-style 365-day heatmap (5 intensity buckets, 7×N grid)
- Weekly / monthly bar chart with `Week / Month / Quarter / Year` range picker
- Manual refresh button

**New: Settings UI — model picker**
A unified picker section replaces the provider-specific segmented pickers. It shows model ID, family, context window, vision-capable badge, recommended / deprecated flags, "Last refreshed" timestamp, and a `↻` refresh button. For ChatGPT/Claude CLI a per-tool picker is rendered so the user can run `gpt-5.4` on Codex and `claude-haiku-4-5` on Claude at the same time.

**Modified: `LLMService`**
`makeBatchProvider` and `makeTextProvider` now read the user-selected model out of `UserDefaults` and forward it to the provider. A new `resolvedModel(for:)` helper centralises the lookup, and a new `attachMeta(_:providerID:model:)` helper stamps every card before it's persisted.

**Modified: `ChatCLIProvider`**
Gained a `defaultModel: String?` parameter that overrides the previously hard-coded `"sonnet"` / `"haiku"` / `"gpt-5.4"` strings. `ChatCLIProcessRunner` already supported a `model:` argument — we just feed it now.

**Modified: `ActivityCardData` / `TimelineCard` / `TimelineCardShell`**
All three gained `providerId: String?` and `modelId: String?` properties. `CanvasActivityCard` renders this as a small inline badge below the time label (`MiniMax · MiniMax-M3`, `Claude · Sonnet 4.5`, `Local · qwen3-vl:4b`).

**Modified: SQLite schema**
`ALTER TABLE timeline_cards ADD COLUMN provider_id TEXT; ADD COLUMN model_id TEXT;` plus a composite index `idx_timeline_cards_provider_model`. New `StorageManager.fetchAllTimelineCards()` query reads them.

### Privacy & data handling

- **No new outbound destinations** beyond what the user has already configured. The ModelCatalog talks to whichever provider the user has already enabled; it never dials home to anything Dayflow-owned.
- **No screenshot content leaves the device.** The dashboard reads only the metadata already persisted locally; it never touches the LLM call log or the video chunks.
- **No new telemetry.** `AnalyticsService.sanitize()` continues to block `api_key`, `token`, `authorization`, `file_path`, `url`, `window_title`, `clipboard`, `screen_content`.
- **Keychain only.** API keys continue to live in the macOS Keychain (key `com.teleportlabs.dayflow.apikeys.minimax` for MiniMax).
- All model IDs cached in `UserDefaults` are non-sensitive.

### Testing

```bash
xcodebuild -project Dayflow.xcodeproj -scheme Dayflow \
  -configuration Release -destination 'platform=macOS' \
  CODE_SIGNING_ALLOWED=NO build
# → ** BUILD SUCCEEDED **
```

Manually verified:
- Model picker populates from the Gemini live API and from the curated MiniMax fallback (since `api.minimax.io/v1/models` requires auth, the curated M-series list is what users see until they put their key in; once the key is in, the live list takes over).
- Refresh button re-fetches.
- Per-card badge appears on the timeline and survives a relaunch (it's persisted to SQLite).
- Dashboard renders a 365-day heatmap, provider bar chart, and weekly/monthly/quarterly time series.

### Risk / rollback

- The model picker is opt-in. If a user never opens Settings → Providers, the previous behaviour (provider's hard-coded default) is preserved.
- The dashboard is a new view; it doesn't touch the existing timeline, day view, or week view.
- Reverting the PR removes the picker, the badge, and the dashboard. No persisted state is added unless the user explicitly opens the dashboard (which writes nothing) or the LLMService stamps new cards with metadata (which is purely additive).

### Files

| | |
|---|---|
| New | `Dayflow/Dayflow/Core/AI/ModelCatalog.swift` |
| New | `Dayflow/Dayflow/Core/Analytics/ProviderStatsCalculator.swift` |
| New | `Dayflow/Dayflow/Views/UI/Dashboard/ProviderStatsView.swift` |
| Modified | 17 files in `Core/AI/`, `Core/Recording/`, `Views/UI/` |
| Total | 20 files changed, 1 950 insertions, 93 deletions |

### Related

- Companion: #320 (MiniMax M3 provider)
- Vendor docs: <https://platform.minimax.io/docs/api-reference/text-openai-api>, <https://ai.google.dev/api/models>, <https://docs.anthropic.com>, <https://ollama.com/docs/api>
- Privacy audit: `PRIVACY_AUDIT.md` (covers both #320 and this PR)
- Research notes: `research/MODEL_CATALOG.md` (sources, deprecation timeline, recommended defaults)
