### PR TITLE
Relax short activity card validation

### DIFF
--- a/Dayflow/Dayflow/Core/AI/AgentCLISupport+Parsing.swift
+++ b/Dayflow/Dayflow/Core/AI/AgentCLISupport+Parsing.swift
@@ -482,7 +482,7 @@ extension AgentCLISupporting {
         durationMinutes = Double(endSeconds - startSeconds) / 60.0
       }
 
-      if durationMinutes < 10 && index < cards.count - 1 {
+      if durationMinutes < 1 && index < cards.count - 1 {
         let msg = String(
           format: "Card %d '%@' is only %.1f minutes long", index + 1, card.title, durationMinutes)
         return (false, msg)

--- a/Dayflow/Dayflow/Core/AI/GeminiDirectProvider+ActivityCards.swift
+++ b/Dayflow/Dayflow/Core/AI/GeminiDirectProvider+ActivityCards.swift
@@ -904,8 +904,9 @@ extension GeminiDirectProvider {
         durationMinutes = Double(endSeconds - startSeconds) / 60.0
       }
 
-      // Check if card is too short (except for last card)
-      if durationMinutes < 10 && index < cards.count - 1 {
+      // Reject only invalid or near-zero middle fragments. Short context
+      // transitions should not fail an otherwise usable activity-card batch.
+      if durationMinutes < 1 && index < cards.count - 1 {
         return (
           false,
           "Card \(index + 1) '\(card.title)' is only \(String(format: "%.1f", durationMinutes)) minutes long"

--- a/Dayflow/DayflowTests/CodexClaudeProviderTests.swift
+++ b/Dayflow/DayflowTests/CodexClaudeProviderTests.swift
@@ -150,17 +150,25 @@ final class CodexClaudeProviderTests: XCTestCase {
     )
   }
 
-  func testLegacyCardDurationOnlyRejectsShortNonFinalCards() {
+  func testLegacyCardDurationAllowsShortTransitionsButRejectsInvalidRanges() {
     XCTAssertTrue(
       claudeProvider.validateTimeline([
         card(start: "9:00 AM", end: "10:30 AM", title: "Long card"),
         card(start: "10:30 AM", end: "10:35 AM", title: "Short final card"),
       ]).isValid
     )
+
+    XCTAssertTrue(
+      claudeProvider.validateTimeline([
+        card(start: "9:00 AM", end: "9:05 AM", title: "Short transition"),
+        card(start: "9:05 AM", end: "9:20 AM", title: "Final card"),
+      ]).isValid
+    )
+
     XCTAssertFalse(
       claudeProvider.validateTimeline([
-        card(start: "9:00 AM", end: "9:05 AM", title: "Short non-final card"),
-        card(start: "9:05 AM", end: "9:20 AM", title: "Final card"),
+        card(start: "9:00 AM", end: "9:00 AM", title: "Invalid non-final card"),
+        card(start: "9:00 AM", end: "9:20 AM", title: "Final card"),
       ]).isValid
     )
   }


### PR DESCRIPTION
## Summary

Relax activity-card duration validation so short transition cards do not fail an otherwise usable timeline batch.

## Why

Some providers occasionally return coherent short transition cards in the middle of a capture window. Previously, cards under 10 minutes caused the entire batch to fail, even when the generated timeline was otherwise useful. This could create unnecessary "Processing failed" cards and force manual retry.

## Changes

- Reject only invalid or near-zero middle cards under 1 minute.
- Preserve validation for invalid card ranges.
- Update provider validation tests to cover short transitions and invalid ranges.

## Validation

- `xcodebuild test -project Dayflow/Dayflow.xcodeproj -scheme Dayflow -destination 'platform=macOS' -derivedDataPath DerivedDataUpstreamPR CODE_SIGNING_ALLOWED=NO -only-testing:DayflowTests`

Note: a full local test run reached unit tests but hit an unrelated `DayflowUITests-Runner` bootstrap crash.
