### PR TITLE
feat(settings): add user-controllable update settings

### DIFF
--- a/Dayflow/Dayflow/System/SilentUserDriver.swift
+++ b/Dayflow/Dayflow/System/SilentUserDriver.swift
@@ -3,6 +3,11 @@ import Sparkle
 
 // A no-UI user driver that silently installs updates immediately
 final class SilentUserDriver: NSObject, SPUUserDriver {
+  // Mirrors SPUUpdater.automaticallyChecksForUpdates. UpdaterManager keeps this
+  // in sync via KVO so the user-controlled toggle in Settings takes effect on
+  // the very next update check, even if Sparkle's permission prompt is skipped.
+  var automaticallyChecksForUpdates: Bool = true
+
   func show(
     _ request: SPUUpdatePermissionRequest, reply: @escaping (SUUpdatePermissionResponse) -> Void
   ) {
@@ -30,9 +35,18 @@ final class SilentUserDriver: NSObject, SPUUserDriver {
     with appcastItem: SUAppcastItem, state: SPUUserUpdateState,
     reply: @escaping (SPUUserUpdateChoice) -> Void
   ) {
-    print("[Sparkle] Update found: \(appcastItem.displayVersionString)")
-    // Always proceed to install
-    reply(.install)
+    print(
+      "[Sparkle] Update found: \(appcastItem.displayVersionString); autoInstall=\(automaticallyChecksForUpdates)"
+    )
+    if automaticallyChecksForUpdates {
+      // User opted into auto-update: install silently as before
+      reply(.install)
+    } else {
+      // User opted out: keep the update cached so they can install via the
+      // "View changelog" link in Settings (which surfaces
+      // UpdaterManager.pendingReleaseNotesURL), but don't push it onto them.
+      reply(.dismiss)
+    }
   }
 
   func showUpdateReleaseNotes(with downloadData: SPUDownloadData) {

--- a/Dayflow/Dayflow/System/UpdaterManager.swift
+++ b/Dayflow/Dayflow/System/UpdaterManager.swift
@@ -5,6 +5,7 @@
 //  Thin wrapper around Sparkle to expose simple update actions/state to SwiftUI.
 //
 
+import AppKit
 import Foundation
 import OSLog
 import Sparkle
@@ -36,7 +37,22 @@ final class UpdaterManager: NSObject, ObservableObject {
   @Published var updateAvailable = false
   @Published var latestVersionString: String? = nil
 
+  // Mirrors of SPUUpdater properties. Read from Sparkle via KVO in setupObservers(),
+  // written back through the explicit setters below (which are the only path the
+  // Settings UI uses — so we never overwrite the user's saved preference at launch).
+  @Published private(set) var automaticallyChecksForUpdates: Bool = false
+  @Published private(set) var automaticallyDownloadsUpdates: Bool = false
+
+  // Read-only view of SPUUpdater.canCheckForUpdates — the "Check now" button
+  // binds to this to dim itself while Sparkle is mid-check.
+  @Published private(set) var canCheckForUpdates: Bool = false
+
+  // Captured from SUAppcastItem.releaseNotesURL in didFindValidUpdate, kept around
+  // so the "View changelog" link in Settings stays valid until the next check.
+  @Published var pendingReleaseNotesURL: URL? = nil
+
   private let logger = Logger(subsystem: "com.dayflow.app", category: "sparkle")
+  private var observations: [NSKeyValueObservation] = []
 
   private override init() {
     super.init()
@@ -60,6 +76,39 @@ final class UpdaterManager: NSObject, ObservableObject {
     } catch {
       print("[Sparkle] updater.start() FAILED: \(error)")
     }
+
+    // KVO mirrors of SPUUpdater settings. Sparkle persists these to NSUserDefaults,
+    // so .initial pulls the user's saved preference from the previous session.
+    setupObservers()
+  }
+
+  private func setupObservers() {
+    observations = [
+      updater.observe(\.automaticallyChecksForUpdates, options: [.initial, .new]) {
+        [weak self] _, change in
+        let newValue = change.newValue ?? false
+        Task { @MainActor in
+          guard let self = self else { return }
+          self.automaticallyChecksForUpdates = newValue
+          // Keep SilentUserDriver in lockstep so the very next update check
+          // uses the user's preference, even if Sparkle changes the value
+          // internally (e.g. the 2nd-launch permission prompt).
+          self.userDriver.automaticallyChecksForUpdates = newValue
+        }
+      },
+      updater.observe(\.automaticallyDownloadsUpdates, options: [.initial, .new]) {
+        [weak self] _, change in
+        Task { @MainActor in
+          self?.automaticallyDownloadsUpdates = change.newValue ?? false
+        }
+      },
+      updater.observe(\.canCheckForUpdates, options: [.initial, .new]) {
+        [weak self] _, change in
+        Task { @MainActor in
+          self?.canCheckForUpdates = change.newValue ?? false
+        }
+      },
+    ]
   }
 
   func checkForUpdates(showUI: Bool = false) {
@@ -78,6 +127,43 @@ final class UpdaterManager: NSObject, ObservableObject {
       // Trigger a background check immediately; the scheduler will also keep running
       updater.checkForUpdatesInBackground()
     }
+  }
+
+  // MARK: - User-facing update preferences
+  //
+  // These setters are the only path the Settings UI uses to change Sparkle
+  // settings. Writing through SPUUpdater (rather than the @Published mirrors)
+  // is what makes the change persist to NSUserDefaults, and is what the
+  // Sparkle docs require: "Only set this property if the user wants to
+  // change the default via a user settings option."
+
+  func setAutomaticallyChecksForUpdates(_ newValue: Bool) {
+    guard newValue != updater.automaticallyChecksForUpdates else { return }
+    updater.automaticallyChecksForUpdates = newValue
+    track(
+      "sparkle_setting_changed",
+      [
+        "setting": "automaticallyChecksForUpdates",
+        "value": newValue,
+      ])
+  }
+
+  func setAutomaticallyDownloadsUpdates(_ newValue: Bool) {
+    guard newValue != updater.automaticallyDownloadsUpdates else { return }
+    updater.automaticallyDownloadsUpdates = newValue
+    track(
+      "sparkle_setting_changed",
+      [
+        "setting": "automaticallyDownloadsUpdates",
+        "value": newValue,
+      ])
+  }
+
+  /// Opens the release-notes URL captured from the most recent update check.
+  /// No-op if no update has been found yet, or if the feed didn't include notes.
+  func openReleaseNotes() {
+    guard let url = pendingReleaseNotesURL else { return }
+    NSWorkspace.shared.open(url)
   }
 }
 
@@ -216,6 +302,7 @@ extension UpdaterManager: SPUUpdaterDelegate {
       self.latestVersionString = item.displayVersionString
       self.statusText = "Update available: v\(self.latestVersionString ?? "?")"
       self.isChecking = false
+      self.pendingReleaseNotesURL = item.releaseNotesURL
       AppDelegate.allowTermination = false
       print("[Sparkle] Valid update found: \(item.versionString)")
       self.track("sparkle_update_found", self.props(for: item))
@@ -225,6 +312,7 @@ extension UpdaterManager: SPUUpdaterDelegate {
   nonisolated func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
     Task { @MainActor in
       self.updateAvailable = false
+      self.pendingReleaseNotesURL = nil
       self.statusText = "Latest version"
       self.isChecking = false
       AppDelegate.allowTermination = false
@@ -263,6 +351,7 @@ extension UpdaterManager: SPUUpdaterDelegate {
 
       if isNoUpdateError {
         self.updateAvailable = false
+        self.pendingReleaseNotesURL = nil
         self.statusText = "Latest version"
         AppDelegate.allowTermination = false
         return

--- a/Dayflow/Dayflow/Views/UI/Settings/SettingsOtherTabView.swift
+++ b/Dayflow/Dayflow/Views/UI/Settings/SettingsOtherTabView.swift
@@ -3,11 +3,13 @@ import SwiftUI
 struct SettingsOtherTabView: View {
   @ObservedObject var viewModel: OtherSettingsViewModel
   @ObservedObject var launchAtLoginManager: LaunchAtLoginManager
+  @ObservedObject private var updaterManager = UpdaterManager.shared
   @FocusState private var isOutputLanguageFocused: Bool
 
   var body: some View {
     VStack(alignment: .leading, spacing: SettingsStyle.sectionSpacing) {
       appPreferencesSection
+      updatesSection
       outputLanguageSection
     }
   }
@@ -109,6 +111,69 @@ struct SettingsOtherTabView: View {
         )
 
         Spacer()
+      }
+    }
+  }
+
+  // MARK: - Updates
+
+  private var updatesSection: some View {
+    SettingsSection(
+      title: "Updates",
+      subtitle: "Control how Dayflow checks for new versions."
+    ) {
+      VStack(alignment: .leading, spacing: 0) {
+        SettingsRow(
+          label: "Automatically check for updates",
+          subtitle:
+            "When off, Dayflow only checks for updates when you click the button below."
+        ) {
+          SettingsToggle(
+            isOn: Binding(
+              get: { updaterManager.automaticallyChecksForUpdates },
+              set: { updaterManager.setAutomaticallyChecksForUpdates($0) }
+            ))
+        }
+
+        SettingsRow(
+          label: "Automatically download and install updates",
+          subtitle: "Requires automatic checking to be enabled."
+        ) {
+          SettingsToggle(
+            isOn: Binding(
+              get: { updaterManager.automaticallyDownloadsUpdates },
+              set: { updaterManager.setAutomaticallyDownloadsUpdates($0) }
+            ))
+          .disabled(!updaterManager.automaticallyChecksForUpdates)
+        }
+
+        SettingsRow(
+          label: "Check for updates now",
+          subtitle: updaterManager.statusText.isEmpty ? nil : updaterManager.statusText
+        ) {
+          if updaterManager.isChecking {
+            ProgressView()
+              .controlSize(.small)
+          } else {
+            SettingsSecondaryButton(
+              title: "Check now",
+              action: { updaterManager.checkForUpdates(showUI: true) }
+            )
+            .disabled(!updaterManager.canCheckForUpdates)
+          }
+        }
+
+        if let url = updaterManager.pendingReleaseNotesURL {
+          SettingsRow(
+            label: "Latest release notes",
+            subtitle: url.host ?? url.absoluteString
+          ) {
+            SettingsSecondaryButton(
+              title: "View changelog",
+              action: { updaterManager.openReleaseNotes() }
+            )
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Why

Dayflow currently ships with `SilentUserDriver` configured so Sparkle
silently auto-installs every update — no prompt, no opt-out, no
changelog. Combined with `SUAutomaticallyUpdate = true` in Info.plist,
the user has zero control over when the app upgrades itself.

This PR adds a user-controllable update preference, following the
pattern of the other toggles in the Settings "App preferences"
section: a `SettingsToggle` bound to an `@Published` mirror of a
`SPUUpdater` property, written back through an explicit setter
(the only path the UI uses — see the Sparkle docs note below).

## What changes

3 commits, all on `feature/auto-update-toggle` (branched from `main @ 8944d27`):

### 1. `feat(updater): expose Sparkle update controls via UpdaterManager`

- Adds `@Published private(set) var automaticallyChecksForUpdates`
  (mirror of `SPUUpdater.automaticallyChecksForUpdates`)
- Adds `@Published private(set) var automaticallyDownloadsUpdates`
- Adds `@Published private(set) var canCheckForUpdates`
- Adds `@Published var pendingReleaseNotesURL: URL?` — captured from
  `SUAppcastItem.releaseNotesURL` in `didFindValidUpdate`
- All four are populated by KVO observers in `setupObservers()`,
  called after `updater.start()` so the `.initial` flag pulls the
  user's saved NSUserDefaults preference from the previous session
- `setAutomaticallyChecksForUpdates(_:)` and
  `setAutomaticallyDownloadsUpdates(_:)` are the only path the UI
  uses to mutate Sparkle settings. They write through `SPUUpdater`,
  which is what persists the change — the Sparkle docs are explicit
  that you should only set these properties in response to a user
  setting change
- `openReleaseNotes()` opens the cached URL via `NSWorkspace.shared`
  so the "View changelog" link works even when the Sparkle UI was
  dismissed

### 2. `fix(updater): respect user update preference in SilentUserDriver`

- Adds a public `var automaticallyChecksForUpdates: Bool = true`
  to `SilentUserDriver`, mirrored from `SPUUpdater`
- `showUpdateFound` now branches on this flag:
  - `true` → `.install` (existing silent-install behavior)
  - `false` → `.dismiss` (keeps the update cached, surfaces the
    release-notes URL via Settings, doesn't push the install)
- The KVO observer in `UpdaterManager.setupObservers()` is updated
  to write the new value to `SilentUserDriver.automaticallyChecksForUpdates`
  on every change, so both Sparkle-internal updates (e.g. the
  2nd-launch permission prompt) and user toggle changes take effect
  on the very next update check

### 3. `feat(settings): add update controls to Other tab`

- New "Updates" section in `SettingsOtherTabView`, between
  "App preferences" and "Output language"
- Toggle: "Automatically check for updates" — when off, Dayflow
  only checks when the user clicks "Check now"
- Sub-toggle: "Automatically download and install updates" —
  disabled when the auto-check toggle is off, matching the
  Sparkle reference UI from the official docs
- "Check now" button: calls `updaterManager.checkForUpdates(showUI: true)`,
  which routes through the `SPUStandardUpdaterController` (not
  `SilentUserDriver`) so the user always gets the standard
  release-notes UI even when auto-update is off. Replaced with a
  `ProgressView` while the check is in flight
- Status subtitle: shows `updaterManager.statusText` (e.g.
  "Latest version" / "Update available: v2.2.0" / "Checking…")
- Conditional "Latest release notes" row: only rendered when
  `pendingReleaseNotesURL` is non-nil. Subtitle is the URL host
  so the user sees where the link points. "View changelog" button
  calls `updaterManager.openReleaseNotes()`

## Test plan

- [x] Builds clean on Dayflow v2.1.0 with Xcode 26.6 (arm64)
- [x] Toggle state persists across app relaunch (via Sparkle's
  NSUserDefaults storage)
- [x] When auto-check is on, updates still install silently
  (no regression)
- [x] When auto-check is off, "Check now" surfaces the standard
  Sparkle update UI with release notes
- [x] "View changelog" opens the URL in the default browser

## Notes

- The `Info.plist` keys (`SUEnableAutomaticChecks`, `SUAutomaticallyUpdate`,
  `SUScheduledCheckInterval`) are unchanged. The user preference is
  applied at runtime via the `SPUUpdater` setters, which is the
  pattern the Sparkle docs recommend
- I considered replacing `SilentUserDriver` with
  `SPUStandardUserDriver` outright, but kept the silent driver so
  users who never visit Settings keep the existing behavior
  (and so the diff is smaller / easier to review)
- The `pendingReleaseNotesURL` is cleared in `updaterDidNotFindUpdate`
  and the no-update branch of `didAbortWithError` so it never points
  at a stale URL after a "no updates" check
