### PR TITLE
fix(privacy): stop sending chat question text to analytics, harden sanitizer

### DIFF
--- a/Dayflow/Dayflow/System/AnalyticsService.swift
+++ b/Dayflow/Dayflow/System/AnalyticsService.swift
@@ -563,21 +563,19 @@ final class AnalyticsService {
   }
 
   private func sanitize(_ props: [String: Any]) -> [String: Any] {
-    // Drop known sensitive keys if ever passed by mistake
     let blocked = Set([
       "api_key", "token", "authorization", "file_path", "url", "window_title", "clipboard",
-      "screen_content",
+      "screen_content", "question",
     ])
     var out: [String: Any] = [:]
     for (k, v) in props {
       if blocked.contains(k) { continue }
-      // Only allow primitive JSON types
+      // Only allow primitive JSON types; drop complex values to prevent
+      // String(describing:) from serializing nested sensitive content.
       if v is String || v is Int || v is Double || v is Bool || v is NSNull {
         out[k] = v
-      } else {
-        // Allow string coercion for simple enums
-        out[k] = String(describing: v)
       }
+      // Non-primitive values are silently dropped (not string-coerced)
     }
     return out
   }

--- a/Dayflow/Dayflow/Views/UI/ChatView+Actions.swift
+++ b/Dayflow/Dayflow/Views/UI/ChatView+Actions.swift
@@ -34,7 +34,7 @@ extension ChatView {
     AnalyticsService.shared.capture(
       "chat_question_asked",
       [
-        "question": messageText,
+        "question_length": messageText.count,
         "conversation_id": conversationId?.uuidString ?? "unknown",
         "is_new_conversation": isNewConversation,
         "message_index": messageIndex,


### PR DESCRIPTION
## Why

Two privacy issues were found in the analytics layer:

1. **`chat_question_asked` sends the user's literal question text to PostHog.** The event included `"question": messageText` — the raw text the user typed into the chat input. This is not hashed, not truncated, not sanitized. The `sanitize()` denylist does not catch it because the key is `"question"`, not one of the 8 blocked keys.

2. **`AnalyticsService.sanitize()` has an exfiltration channel via `String(describing:)`.** Non-primitive values (dictionaries, arrays, URLs, custom objects) are string-coerced via `String(describing:)` instead of being dropped. This can leak nested sensitive content — e.g. a dictionary containing `api_key` or `token` values gets serialized into a string and forwarded to PostHog.

## What changes

### Fix 1: Replace question text with character count

`ChatView+Actions.swift` — the `chat_question_asked` event now sends `"question_length": messageText.count` instead of `"question": messageText`. All other properties (`conversation_id`, `is_new_conversation`, `message_index`, `provider`, `chat_runtime`) remain unchanged.

### Fix 2: Add "question" to denylist + drop non-primitive values

`AnalyticsService.swift` — two changes to `sanitize(_:)`:

- **2a**: Added `"question"` to the `blocked` keys set as defense-in-depth, so any future caller can't accidentally send chat input
- **2b**: Removed the `else { out[k] = String(describing: v) }` branch. Non-primitive values (dictionaries, arrays, custom objects, URLs) are now silently dropped instead of being string-serialized. This closes the nested-content exfiltration channel identified in the privacy audit.

## Impact

- No analytics events lose data — only the `question` text field is removed (replaced with a count)
- Non-primitive property values that were previously string-coerced are now dropped. In practice, all current callers send primitive types (String, Int, Bool, Double), so no existing events are affected
- The denylist is now 9 keys (was 8): `api_key`, `token`, `authorization`, `file_path`, `url`, `window_title`, `clipboard`, `screen_content`, `question`

## Test plan

- [x] `chat_question_asked` sends `question_length` (Int), not `question` (String)
- [x] `sanitize()` drops any value under the key `"question"`
- [x] `sanitize()` drops non-primitive values instead of `String(describing:)` coercion
- [x] All other analytics events are unaffected (they already send primitives)