### PR TITLE
fix(security): move Gemini API key from URL query to x-goog-api-key header

### DIFF
--- a/Dayflow/Dayflow/Core/AI/GeminiDirectProvider+ActivityCards.swift
+++ b/Dayflow/Dayflow/Core/AI/GeminiDirectProvider+ActivityCards.swift
@@ -391,10 +391,11 @@ extension GeminiDirectProvider {
     ]
 
     // Single API call (retry logic handled by outer loop in generateActivityCards)
-    let urlWithKey = endpointForModel(model) + "?key=\(apiKey)"
-    var request = URLRequest(url: URL(string: urlWithKey)!)
+    let url = endpointForModel(model)
+    var request = URLRequest(url: URL(string: url)!)
     request.httpMethod = "POST"
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
     request.timeoutInterval = 120  // 2 minutes timeout
     let requestStart = Date()
 
@@ -573,7 +574,9 @@ extension GeminiDirectProvider {
       if let urlError = error as? URLError {
         print("   URLError Code: \(urlError.code.rawValue) (\(urlError.code))")
         if let failingURL = urlError.failingURL {
-          print("   Failing URL: \(failingURL.absoluteString)")
+          var comps = URLComponents(url: failingURL, resolvingAgainstBaseURL: false)
+          comps?.queryItems = nil
+          print("   Failing URL: \(comps?.url?.absoluteString ?? "<unavailable>")")
         }
 
         // Check for specific network errors

--- a/Dayflow/Dayflow/Core/AI/GeminiDirectProvider+DashboardStreaming.swift
+++ b/Dayflow/Dayflow/Core/AI/GeminiDirectProvider+DashboardStreaming.swift
@@ -12,9 +12,10 @@ extension GeminiDirectProvider {
       contents: contents,
       includeThinkingConfig: includeThinkingConfig
     )
-    var request = URLRequest(url: URL(string: dashboardStreamEndpoint + "?alt=sse&key=\(apiKey)")!)
+    var request = URLRequest(url: URL(string: dashboardStreamEndpoint + "?alt=sse")!)
     request.httpMethod = "POST"
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
     request.timeoutInterval = 180
     request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
 
@@ -101,9 +102,10 @@ extension GeminiDirectProvider {
       contents: contents,
       includeThinkingConfig: includeThinkingConfig
     )
-    var request = URLRequest(url: URL(string: dashboardGenerateEndpoint + "?key=\(apiKey)")!)
+    var request = URLRequest(url: URL(string: dashboardGenerateEndpoint)!)
     request.httpMethod = "POST"
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
     request.timeoutInterval = 180
     request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
 

--- a/Dayflow/Dayflow/Core/AI/GeminiDirectProvider+Text.swift
+++ b/Dayflow/Dayflow/Core/AI/GeminiDirectProvider+Text.swift
@@ -27,11 +27,12 @@ extension GeminiDirectProvider {
       do {
         print("🔄 generateText attempt \(attempt + 1)/\(maxRetries)")
         let activeModel = modelState.current
-        let urlWithKey = endpointForModel(activeModel) + "?key=\(apiKey)"
+        let url = endpointForModel(activeModel)
 
-        var request = URLRequest(url: URL(string: urlWithKey)!)
+        var request = URLRequest(url: URL(string: url)!)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
         request.timeoutInterval = 120
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
 

--- a/Dayflow/Dayflow/Core/AI/GeminiDirectProvider+Transcription.swift
+++ b/Dayflow/Dayflow/Core/AI/GeminiDirectProvider+Transcription.swift
@@ -296,10 +296,11 @@ extension GeminiDirectProvider {
     ]
 
     // Single API call (no retry logic in this function)
-    let urlWithKey = endpointForModel(model) + "?key=\(apiKey)"
-    var request = URLRequest(url: URL(string: urlWithKey)!)
+    let url = endpointForModel(model)
+    var request = URLRequest(url: URL(string: url)!)
     request.httpMethod = "POST"
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
     request.timeoutInterval = 120  // 2 minutes timeout
     let requestStart = Date()
 
@@ -527,7 +528,9 @@ extension GeminiDirectProvider {
       if let urlError = error as? URLError {
         print("   URLError Code: \(urlError.code.rawValue) (\(urlError.code))")
         if let failingURL = urlError.failingURL {
-          print("   Failing URL: \(failingURL.absoluteString)")
+          var comps = URLComponents(url: failingURL, resolvingAgainstBaseURL: false)
+          comps?.queryItems = nil
+          print("   Failing URL: \(comps?.url?.absoluteString ?? "<unavailable>")")
         }
 
         // Check for specific network errors

--- a/Dayflow/Dayflow/Core/AI/GeminiDirectProvider+Upload.swift
+++ b/Dayflow/Dayflow/Core/AI/GeminiDirectProvider+Upload.swift
@@ -127,9 +127,10 @@ extension GeminiDirectProvider {
   }
 
   func uploadSimple(data: Data, mimeType: String) async throws -> String {
-    var request = URLRequest(url: URL(string: fileEndpoint + "?key=\(apiKey)")!)
+    var request = URLRequest(url: URL(string: fileEndpoint)!)
     request.httpMethod = "POST"
     request.setValue(mimeType, forHTTPHeaderField: "Content-Type")
+    request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
     request.httpBody = data
 
     let requestStart = Date()
@@ -165,13 +166,14 @@ extension GeminiDirectProvider {
     body.append(try JSONEncoder().encode(metadata))
     body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
 
-    var request = URLRequest(url: URL(string: fileEndpoint + "?key=\(apiKey)")!)
+    var request = URLRequest(url: URL(string: fileEndpoint)!)
     request.httpMethod = "POST"
     request.setValue("resumable", forHTTPHeaderField: "X-Goog-Upload-Protocol")
     request.setValue("start", forHTTPHeaderField: "X-Goog-Upload-Command")
     request.setValue("\(data.count)", forHTTPHeaderField: "X-Goog-Upload-Raw-Size")
     request.setValue(mimeType, forHTTPHeaderField: "X-Goog-Upload-Header-Content-Type")
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
     request.httpBody = try JSONEncoder().encode(metadata)
 
     let startTime = Date()
@@ -204,6 +206,7 @@ extension GeminiDirectProvider {
     uploadRequest.httpMethod = "PUT"
     uploadRequest.setValue("upload, finalize", forHTTPHeaderField: "X-Goog-Upload-Command")
     uploadRequest.setValue("0", forHTTPHeaderField: "X-Goog-Upload-Offset")
+    uploadRequest.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
     uploadRequest.httpBody = data
 
     let uploadStartTime = Date()
@@ -247,13 +250,17 @@ extension GeminiDirectProvider {
   }
 
   func getFileStatus(fileURI: String) async throws -> String {
-    guard let url = URL(string: fileURI + "?key=\(apiKey)") else {
+    guard let url = URL(string: fileURI) else {
       throw NSError(
         domain: "GeminiError", code: 6, userInfo: [NSLocalizedDescriptionKey: "Invalid file URI"])
     }
 
+    var request = URLRequest(url: url)
+    request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
+    request.cachePolicy = .reloadIgnoringLocalCacheData
+
     let requestStart = Date()
-    let (data, response) = try await URLSession.shared.data(from: url)
+    let (data, response) = try await URLSession.shared.data(for: request)
     let requestDuration = Date().timeIntervalSince(requestStart)
     let statusCode = (response as? HTTPURLResponse)?.statusCode
     logCallDuration(operation: "file.status", duration: requestDuration, status: statusCode)

--- a/Dayflow/Dayflow/Core/AI/GemmaBackupProvider+Networking.swift
+++ b/Dayflow/Dayflow/Core/AI/GemmaBackupProvider+Networking.swift
@@ -12,10 +12,11 @@ extension GemmaBackupProvider {
     maxOutputTokens: Int,
     logRequestBody: Bool
   ) async throws -> String {
-    let url = URL(string: "\(baseURL)/\(model):generateContent?key=\(apiKey)")!
+    let url = URL(string: "\(baseURL)/\(model):generateContent")!
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
     request.timeoutInterval = 120
 
     let requestBody: [String: Any] = [

--- a/Dayflow/Dayflow/Core/AI/LLMLogger.swift
+++ b/Dayflow/Dayflow/Core/AI/LLMLogger.swift
@@ -165,7 +165,7 @@ enum LLMLogger {
       let redactedKeys = Set([
         "key", "api_key", "apiKey", "access_token", "token", "authorization", "x-goog-api-key",
         "x-api-key",
-      ])
+      ].map { $0.lowercased() })
       comps?.queryItems = items.map { item in
         if redactedKeys.contains(item.name.lowercased()) {
           return URLQueryItem(name: item.name, value: "<redacted>")

--- a/Dayflow/Dayflow/Utilities/GeminiAPIHelper.swift
+++ b/Dayflow/Dayflow/Utilities/GeminiAPIHelper.swift
@@ -94,11 +94,12 @@ final class GeminiAPIHelper {
   {
     let url = URL(
       string:
-        "https://generativelanguage.googleapis.com/v1beta/models/\(model.rawValue):generateContent?key=\(apiKey)"
+        "https://generativelanguage.googleapis.com/v1beta/models/\(model.rawValue):generateContent"
     )!
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
 
     let requestBody: [String: Any] = [
       "contents": [


### PR DESCRIPTION
## Why

The Gemini/Gemma API key was interpolated into URL query strings (`?key=<apiKey>`) on every request, exposing it in:

- **URL logs** — `URLError.failingURL.absoluteString` is printed on network errors, leaking the key to the unified log and `sysdiagnose` bundles
- **HTTP cache** — `URLCache.shared` keys entries by full URL, persisting the key to `~/Library/Caches/.../Cache.db`
- **Proxy traces** — corporate TLS-inspecting proxies log full request lines but often redact headers
- **Server access logs** — Google's own guidance recommends the header method

This contradicts the project's own `PRIVACY_AUDIT.md` which claims "No (key in header)" for Gemini — that claim was inaccurate.

## What changes

Replaces all `?key=<apiKey>` query-string interpolation with the `x-goog-api-key` HTTP header (Google's recommended method) across **8 files, 10 call sites**:

| File | Call sites |
|---|---|
| `GeminiDirectProvider+Text.swift` | `generateText` |
| `GeminiDirectProvider+Transcription.swift` | `transcribeScreenshots` + failingURL redaction |
| `GeminiDirectProvider+ActivityCards.swift` | `generateActivityCards` + failingURL redaction |
| `GeminiDirectProvider+DashboardStreaming.swift` | streaming + non-streaming chat |
| `GeminiDirectProvider+Upload.swift` | simple upload, resumable init, file status polling |
| `GemmaBackupProvider+Networking.swift` | `callGenerateContent` |
| `GeminiAPIHelper.swift` | connection test |
| `LLMLogger.swift` | redaction case bug fix |

### Additional fixes

- **failingURL redaction**: `URLError.failingURL.absoluteString` now strips query parameters before printing, so the key never reaches the log even if a future call site forgets the header
- **LLMLogger redaction bug**: the `redactedKeys` set contained `"apiKey"` but the code did `item.name.lowercased()` → `"apikey"`, which matched neither `"api_key"` nor `"apiKey"`. All set entries are now lowercased for consistent matching
- **Cache policy**: `getFileStatus` polling GET now uses `.reloadIgnoringLocalCacheData` to prevent key persistence in the disk cache

## Safety

- `x-goog-api-key` is already known to `LLMLogger.sanitizeHeaders` (it drops it), so the key is not persisted to the SQLite LLM call log
- The `x-goog-api-key` header is Google's officially documented authentication method for the Generative Language API
- No functional behavior change — same API, same auth, just a different transport

## Test plan

- [x] `rg -n '\?key='` over the Dayflow source returns zero matches
- [x] All 10 call sites now set `x-goog-api-key` header instead of `?key=` query param
- [x] failingURL print statements strip query params before logging
- [x] LLMLogger redactedKeys set is fully lowercased